### PR TITLE
Javamop agent bundle recording specs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ emop-plugin/target/
 .classpath
 .project
 .settings/
+
+scripts/javamop-agent-bundle/specs.txt

--- a/scripts/javamop-agent-bundle/BaseAspect.aj
+++ b/scripts/javamop-agent-bundle/BaseAspect.aj
@@ -1,0 +1,23 @@
+public aspect BaseAspect {
+  pointcut notwithin() :
+  !within(sun..*) &&
+  !within(java..*) &&
+  !within(javax..*) &&
+  !within(javafx..*) &&
+  !within(com.sun..*) &&
+  !within(org.dacapo.harness..*) &&
+  !within(net.sf.cglib..*) &&
+  !within(mop..*) &&
+  !within(javamoprt..*) &&
+  !within(rvmonitorrt..*) &&
+  !within(org.junit..*) &&
+  !within(junit..*) &&
+  !within(java.lang.Object) &&
+  !within(com.runtimeverification..*) &&
+  !within(org.apache.maven.surefire..*) &&
+  !within(org.mockito..*) &&
+  !within(org.powermock..*) &&
+  !within(org.easymock..*) &&
+  !within(com.mockrunner..*) &&
+  !within(org.jmock..*);
+}

--- a/scripts/javamop-agent-bundle/BaseAspect_new.aj
+++ b/scripts/javamop-agent-bundle/BaseAspect_new.aj
@@ -1,0 +1,25 @@
+package mop;
+
+public aspect BaseAspect {
+  pointcut notwithin() :
+  !within(sun..*) &&
+  !within(java..*) &&
+  !within(javax..*) &&
+  !within(javafx..*) &&
+  !within(com.sun..*) &&
+  !within(org.dacapo.harness..*) &&
+  !within(net.sf.cglib..*) &&
+  !within(mop..*) &&
+  !within(javamoprt..*) &&
+  !within(rvmonitorrt..*) &&
+  !within(org.junit..*) &&
+  !within(junit..*) &&
+  !within(java.lang.Object) &&
+  !within(com.runtimeverification..*) &&
+  !within(org.apache.maven.surefire..*) &&
+  !within(org.mockito..*) &&
+  !within(org.powermock..*) &&
+  !within(org.easymock..*) &&
+  !within(com.mockrunner..*) &&
+  !within(org.jmock..*);
+}

--- a/scripts/javamop-agent-bundle/README.txt
+++ b/scripts/javamop-agent-bundle/README.txt
@@ -1,0 +1,12 @@
+cd ${HOME}/javamop-agent-bundle/
+
+# Make the agent
+bash make-agent.sh props agents quiet
+
+# install the agent
+mvn install:install-file -Dfile=agents/JavaMOPAgent.jar -DgroupId="javamop-agent" -DartifactId="javamop-agent" -Dversion="1.0" -Dpackaging="jar"
+
+# Read instructions for adding JavaMOP to your project:
+# https://github.com/runtimeverification/javamop/blob/emop/docs/JavaMOPAgentUsage.md#using-a-java-agent
+
+# For Maven, if you have installed the agent as instructed above, you should replace '-javaagent:JavaMOPAgent.jar' with '-javaagent:${settings.localRepository}/javamop-agent/javamop-agent/1.0/javamop-agent-1.0.jar' when you follow the instructions in the GitHUb link above

--- a/scripts/javamop-agent-bundle/make-agent.sh
+++ b/scripts/javamop-agent-bundle/make-agent.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+SCRIPT_DIR=$( cd $( dirname $0 ) && pwd )
+
+if [ $# != 3 ]; then
+    echo "Usage: $0 property-directory output-directory mode"
+    echo "       mode: {verbose|quiet}"
+    exit
+fi
+
+props_dir=$1
+out_dir=$2
+mode=$3
+
+function build_agent() {
+    local agent_name=$1
+    # This is how to build JavaMOP agents as of 03/23/2016.
+    # https://github.com/runtimeverification/javamop/blob/master/docs/JavaMOPAgentUsage.md
+    local prop_files=${props_dir}/*.mop
+    for spec in ${prop_files}
+    do
+      javamop -baseaspect ${SCRIPT_DIR}/BaseAspect.aj -emop ${spec}
+    done
+    rm -rf ${props_dir}/classes/mop; mkdir -p ${props_dir}/classes/mop
+    rv-monitor -merge -d ${props_dir}/classes/mop/ ${props_dir}/*.rvm #-v
+    javac ${props_dir}/classes/mop/*.java
+    # rm ${props_dir}/classes/mop/*.java
+    cp ${SCRIPT_DIR}/BaseAspect_new.aj ${props_dir}/BaseAspect.aj
+    if [ "${mode}" == "verbose" ]; then
+        echo "AGENT IS VERBOSE!"
+        javamopagent -m -emop ${props_dir}/ ${props_dir}/classes -n ${agent_name} -v
+    elif [ "${mode}" == "quiet" ]; then
+        echo "AGENT IS QUIET!"
+        javamopagent -emop ${props_dir}/ ${props_dir}/classes -n ${agent_name} -v
+    fi
+    mv ${agent_name}.jar ${out_dir}
+}
+
+mkdir -p ${out_dir}
+build_agent JavaMOPAgent

--- a/scripts/javamop-agent-bundle/make-agent.sh
+++ b/scripts/javamop-agent-bundle/make-agent.sh
@@ -33,6 +33,9 @@ function build_agent() {
         echo "AGENT IS QUIET!"
         javamopagent -emop ${props_dir}/ ${props_dir}/classes -n ${agent_name} -v
     fi
+    # recording the list of specs for fast access by RPP mojo
+    find props -name "*.aj" | grep -v BaseAspect.aj | cut -d/ -f2 | cut -d. -f1 > specs.txt
+    jar -uf ${agent_name}.jar specs.txt
     mv ${agent_name}.jar ${out_dir}
 }
 

--- a/scripts/javamop-agent-bundle/props/Appendable_ThreadSafe.mop
+++ b/scripts/javamop-agent-bundle/props/Appendable_ThreadSafe.mop
@@ -1,0 +1,40 @@
+package mop;
+
+import java.io.*;
+import java.lang.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if two threads attempt to use the same Appendable object.
+ *
+ * According to the manual, thread safety is not guaranteed.
+ * http://docs.oracle.com/javase/6/docs/api/java/lang/Appendable.html
+ * While there are some thread-safe Appendable classes, many Appendable
+ * classes are not thread-safe. 
+ *
+ * This property warns if that attempt is detected.
+ *
+ * @severity warning
+ */
+Appendable_ThreadSafe(Appendable a) {
+    Thread owner = null;
+
+    event safe_append before(Appendable a, Thread t) : 
+        call(* Appendable+.append(..)) && target(a) && thread(t) && !target(StringBuffer)
+        && condition(this.owner == null || this.owner == t) {
+            this.owner = t;
+        }
+    
+    event unsafe_append before(Appendable a, Thread t) : 
+        call(* Appendable+.append(..)) && target(a) && thread(t) && !target(StringBuffer)
+        && condition(this.owner != null && this.owner != t) {}
+
+	ere: safe_append*
+
+	@fail {
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "More than two threads attempted to use an Appendable instance, which may lead to a race condition");
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/ArrayDeque_NonNull.mop
+++ b/scripts/javamop-agent-bundle/props/ArrayDeque_NonNull.mop
@@ -1,0 +1,28 @@
+package mop;
+
+import java.util.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if a subclass of ArrayDeque is about to have a null element.
+ *
+ * ArrayDeque does not permit null elements.
+ * http://download.oracle.com/javase/6/docs/api/java/util/ArrayDeque.html
+ *
+ * This property warns if null is about to be inserted.
+ *
+ * @severity error
+ */
+
+ArrayDeque_NonNull() {
+	event insertnull before(Object e) :
+		(
+			call(* ArrayDeque.add*(..)) ||
+			call(* ArrayDeque.offer*(..)) ||
+			call(* ArrayDeque.push(..))
+		) && args(Object+)  && args(e) && condition(e == null) {
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "ArrayDeque does not permit null.");
+	}
+}

--- a/scripts/javamop-agent-bundle/props/ArrayDeque_UnsafeIterator.mop
+++ b/scripts/javamop-agent-bundle/props/ArrayDeque_UnsafeIterator.mop
@@ -1,0 +1,54 @@
+package mop;
+
+import java.util.*;
+import java.lang.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if a deque is modified while an iterator is being used.
+ *
+ * If a deque is modified at any time after an iterator is created, in any
+ * way except through the iterator's own remove() method, the iterator will
+ * generally throw a ConcurrentModificationException. However, the fail-fast
+ * behavior is not guaranteed.
+ * http://docs.oracle.com/javase/6/docs/api/java/util/ArrayDeque.html
+ *
+ * This property warns if a deque is modified while an iterator is being
+ * used. Unlike the underlying system, where the fail-fast behavior is not
+ * guaranteed, this property always detects the problematic behavior.
+ *
+ * @severity error
+ */
+
+ArrayDeque_UnsafeIterator(ArrayDeque q, Iterator i) {
+	creation event create after(ArrayDeque q) returning(Iterator i) :
+		target(ArrayDeque) &&
+		(
+			call(Iterator Iterable+.iterator()) ||
+			call(Iterator Deque+.descendingIterator())
+		) && target(q) {}
+
+	event modify before(ArrayDeque q) :
+		target(ArrayDeque) &&
+		(
+			call(* Collection+.add*(..)) ||
+			call(* Collection+.clear(..)) ||
+			call(* Collection+.offer*(..)) ||
+			call(* Collection+.pop(..)) ||
+			call(* Collection+.push(..)) ||
+			call(* Collection+.remove*(..)) ||
+			call(* Collection+.retain*(..))
+		) && target(q) {}
+
+	event useiter before(Iterator i) :
+		call(* Iterator.*(..)) && target(i) {}
+
+	ere : create useiter* modify+ useiter
+
+	@match {
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "The deque was modified while an iterator is being used.");
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/Arrays_Comparable.mop
+++ b/scripts/javamop-agent-bundle/props/Arrays_Comparable.mop
@@ -1,0 +1,54 @@
+package mop;
+
+import java.util.*;
+import java.lang.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if the argument of Arrays.sort(Object[]) or Arrays.sort(Object[],
+ * int, int) is not comparable.
+ *
+ * All elements in the argument of Arrays.sort() must implement the Comparable
+ * interface, and they must be mutually comparable.
+ * http://docs.oracle.com/javase/6/docs/api/java/util/Arrays.html#sort%28java.lang.Object[]%29
+ *
+ * This property verifies that each element implements the Comparable
+ * interface, and comparing each pair of elements does not raise a
+ * ClassCastException. This property requires O(n^2) time for n elements.
+ *
+ * @severity error
+ */
+
+Arrays_Comparable() {
+	event invalid_sort before(Object[] arr) :
+		target(Arrays) &&
+		(
+			call(void Arrays.sort(Object[])) ||
+			call(void Arrays.sort(Object[], ..))
+		) && args(arr, ..) {
+		for (int i = 0; i < arr.length; ++i) {
+			// Each element must implement the Comparable interface.
+			Object o1 = arr[i];
+			if (!(o1 instanceof Comparable)) {
+				RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+				RVMLogging.out.println(Level.CRITICAL, i + "-th element does not implement the Comparable interface.");
+			}
+			Comparable c1 = (Comparable)o1;
+
+			// All elements must be mutually comparable.
+			for (int j = i + 1; j < arr.length; ++j) {
+				try {
+					Comparable c2 = (Comparable)arr[j];
+					c1.compareTo(c2);
+					c2.compareTo(c1);
+				}
+				catch (ClassCastException e) {
+					RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+					RVMLogging.out.println(Level.CRITICAL, i + "-th element and " + j + "-th element are not comparable.");
+				}
+			}
+		}
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/Arrays_DeepHashCode.mop
+++ b/scripts/javamop-agent-bundle/props/Arrays_DeepHashCode.mop
@@ -1,0 +1,52 @@
+package mop;
+
+import java.util.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if Arrays.deepHashCode() is invoked on an array that contains itself
+ * as an element.
+ *
+ * Arrays.deepHashCode() returns a hash code based on the "deep contents" of
+ * the specified array; i.e., if an element is an array, deepHashCode() is
+ * recursively invoked to get the hash code of that array. As a result,
+ * invoking deepHashCode() on an array that contains itself as an element,
+ * either directly or indirectly, is unacceptable.
+ * http://docs.oracle.com/javase/6/docs/api/java/util/Arrays.html#deepHashCode%28java.lang.Object[]%29
+ *
+ * This property tests if an array can reach itself by recursively iterating
+ * all the elements. If it reaches, this property warns because the behavior
+ * of deepHashCode() is undefined.
+ *
+ * @severity error
+ */
+
+Arrays_DeepHashCode() {
+	private boolean cycle(ArrayList<Object[]> enclosing, Object[] arr) {
+		for (Object[] e : enclosing) {
+			if (e == arr)
+				return true;
+		}
+
+		enclosing.add(arr);
+		for (Object e : arr) {
+			if (e instanceof Object[]) {
+				if (cycle(enclosing, (Object[])e))
+					return true;
+			}
+		}
+		enclosing.remove(enclosing.size() - 1);
+		return false;
+	}
+
+	event invalid_deephashcode before(Object[] arr) :
+		call(int Arrays.deepHashCode(Object[])) && args(arr) {
+		ArrayList<Object[]> enclosing = new ArrayList<Object[]>();
+		if (cycle(enclosing, arr)){
+			RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+			RVMLogging.out.println(Level.CRITICAL, "The specified array contains itself as an element.");
+		}
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/Arrays_MutuallyComparable.mop
+++ b/scripts/javamop-agent-bundle/props/Arrays_MutuallyComparable.mop
@@ -1,0 +1,44 @@
+package mop;
+
+import java.util.*;
+import java.lang.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if the argument of Arrays.sort(T[], Comparator) or Arrays.sort(T[],
+ * int, int, Comparator) is not comparable.
+ *
+ * All elements in the argument of Arrays.sort() must be mutually comparable.
+ * http://docs.oracle.com/javase/6/docs/api/java/util/Arrays.html#sort%28T[],%20java.util.Comparator%29
+ *
+ * This property verifies that comparing each pair of elements does not raise
+ * a ClassCastException. This property requires O(n^2) time for n elements.
+ *
+ * @severity error
+ */
+
+Arrays_MutuallyComparable() {
+	event invalid_sort before(Object[] arr, Comparator comp) :
+		(
+			call(void Arrays.sort(Object[], Comparator)) ||
+			call(void Arrays.sort(Object[], int, int, Comparator))
+		) && args(arr, .., comp) {
+		for (int i = 0; i < arr.length; ++i) {
+			Object o1 = arr[i];
+
+			for (int j = i + 1; j < arr.length; ++j) {
+				Object o2 = arr[j];
+				try {
+					comp.compare(o1, o2);
+					comp.compare(o2, o1);
+				}
+				catch (ClassCastException e) {
+					RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+					RVMLogging.out.println(Level.CRITICAL, i + "-th element and " + j + "-th element are not comparable.");
+				}
+			}
+		}
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/Arrays_SortBeforeBinarySearch.mop
+++ b/scripts/javamop-agent-bundle/props/Arrays_SortBeforeBinarySearch.mop
@@ -1,0 +1,102 @@
+package mop;
+
+import java.util.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if binarySearch() is invoked on an unsorted array.
+ *
+ * Before calling binarySearch(), the array must be sorted into ascending
+ * order.
+ * http://docs.oracle.com/javase/6/docs/api/java/util/Arrays.html#binarySearch%28java.lang.Object[],%20java.lang.Object%29
+ * http://docs.oracle.com/javase/6/docs/api/java/util/Arrays.html#binarySearch%28java.lang.Object[],%20int,%20int,%20java.lang.Object%29
+ *
+ * This property verifies that sort() is invoked before calling
+ * binarySearch(), and no modifications are applied in between two calls.
+ * Since binarySearch() uses compareTo() for comparison, an array sorted using
+ * sort() with a special comparator is not considered sorted.
+ *
+ * Since an array can be sorted without using sort(), this property may report
+ * a false warning.
+ *
+ * @severity error
+ */
+
+Arrays_SortBeforeBinarySearch(Object[] arr) {
+	int fromIndex;
+	int toIndex;
+	Comparator comp = null;
+
+	event sort1 before(Object[] arr) :
+		call(void Arrays.sort(Object[])) && args(arr) {
+		this.fromIndex = 0;
+		this.toIndex = arr.length;
+	}
+	event sort1 before(Object[] arr, int from, int to) :
+		call(void Arrays.sort(Object[], int, int)) && args(arr, from, to) {
+		this.fromIndex = from;
+		this.toIndex = to;
+	}
+
+	event sort2 before(Object[] arr, Comparator comp2) :
+		call(void Arrays.sort(Object[], Comparator)) && args(arr, comp2) {
+		this.fromIndex = 0;
+		this.toIndex = arr.length;
+		this.comp = comp2;
+	}
+	event sort2 before(Object[] arr, int from, int to, Comparator comp2) :
+		call(void Arrays.sort(Object[], int, int, Comparator)) && args(arr, from, to, comp2) {
+		this.fromIndex = from;
+		this.toIndex = to;
+		this.comp = comp2;
+	}
+
+	event modify before(Object[] arr) :
+		set(Object[] *) && args(arr) {
+		this.toIndex = 0;
+	}
+
+	event bsearch1 before(Object[] arr) :
+		call(int Arrays.binarySearch(Object[], Object)) &&
+		args(arr, ..) &&
+		condition(this.fromIndex <= 0 && arr.length <= this.toIndex) {}
+	event bsearch1 before(Object[] arr, int from, int to) :
+		call(int Arrays.binarySearch(Object[], int, int, Object)) &&
+		args(arr, from, to, ..) &&
+		condition(this.fromIndex <= from && to <= this.toIndex) {}
+
+	event bsearch2 before(Object[] arr, Comparator comp2) :
+		call(int Arrays.binarySearch(Object[], Object, Comparator)) &&
+		args(arr, .., comp2) &&
+		condition(this.fromIndex <= 0 && arr.length <= this.toIndex && this.comp == comp2) {}
+	event bsearch2 before(Object[] arr, int from, int to, Comparator comp2) :
+		call(int Arrays.binarySearch(Object[], int, int, Object, Comparator)) &&
+		args(arr, from, to, .., comp2) &&
+		condition(this.fromIndex <= from && to <= this.toIndex && this.comp == comp2) {}
+
+	fsm :
+		unsorted [
+			sort1 -> sorted1
+			sort2 -> sorted2
+			modify -> unsorted
+		]
+		sorted1 [
+			sort1 -> sorted1
+			sort2 -> sorted2
+			modify -> unsorted
+			bsearch1 -> sorted1
+		]
+		sorted2 [
+			sort1 -> sorted1
+			sort2 -> sorted2
+			modify -> unsorted
+			bsearch2 -> sorted2
+		]
+
+	@fail {
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "The array or part of the array must be sorted prior to making binarySearch() call.");
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/Authenticator_OverrideGetPasswordAuthentication.mop
+++ b/scripts/javamop-agent-bundle/props/Authenticator_OverrideGetPasswordAuthentication.mop
@@ -1,0 +1,53 @@
+package mop;
+
+import java.net.*;
+import java.lang.reflect.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if a subclass of Authenticator does not override getPasswordAuthentication().
+ *
+ * Subclasses of Authenticator should override the default implementation,
+ * which returns null.
+ * http://docs.oracle.com/javase/6/docs/api/java/net/Authenticator.html#getPasswordAuthentication%28%29
+ *
+ * This property warns if a class or one of its superclass does not override
+ * getPasswordAuthentication().
+ *
+ * @severity error
+ */
+
+Authenticator_OverrideGetPasswordAuthentication() {
+	event staticinit after() : staticinitialization(Authenticator+) {
+		org.aspectj.lang.Signature initsig = __STATICSIG;
+		Class klass = initsig.getDeclaringType();		
+
+		Method overriden = null;
+		while (klass != null && !klass.getName().equals("java.net.Authenticator")) {
+			try {
+				for (Method m : klass.getDeclaredMethods()) {
+					if (!m.getName().equals("getPasswordAuthentication"))
+						continue;
+					if (m.getParameterTypes().length != 0)
+						continue;
+
+					overriden = m;
+					break;
+				}
+				if (overriden != null)
+					break;
+			}
+			catch (SecurityException e) {
+			}
+
+			klass = klass.getSuperclass();
+		}
+
+		if (overriden == null) {
+			RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+			RVMLogging.out.println(Level.CRITICAL, "An Authenticator class should override the getPasswordAuthentication() method.");
+		}
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/BufferedInputStream_SynchronizedFill.mop
+++ b/scripts/javamop-agent-bundle/props/BufferedInputStream_SynchronizedFill.mop
@@ -1,0 +1,28 @@
+package mop;
+
+import java.io.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if BufferedInputStream.fill() is being called by non-synchronized methods.
+ *
+ * BufferedInputStream.fill() assumes that it is called by synchronized
+ * methods. This property warns if this requirement is not satisfied.
+ *
+ * This property is described in the comments for BufferedInputStream.fill().
+ *
+ * @severity error
+ */
+
+BufferedInputStream_SynchronizedFill(BufferedInputStream i) {
+     event fill before(BufferedInputStream i) : call(* BufferedInputStream.fill(..)) && target(i) && !cflow(call(synchronized * *.*(..))){}
+
+     ere: fill
+
+     @match {
+            RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+            RVMLogging.out.println(Level.CRITICAL, "BufferedInputStream.fill() is being called by a non-synchronized method.");
+     }
+}
+

--- a/scripts/javamop-agent-bundle/props/ByteArrayOutputStream_FlushBeforeRetrieve.mop
+++ b/scripts/javamop-agent-bundle/props/ByteArrayOutputStream_FlushBeforeRetrieve.mop
@@ -1,0 +1,66 @@
+package mop;
+
+import java.io.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Flushes OutputStream before using the underlying ByteArrayOutputStream.
+ *
+ * When an OutputStream (or its subclass) instance is built on top of an
+ * underlying ByteArrayOutputStream instance, it should be flushed or closed
+ * before the underlying instance's toByteArray() is invoked. Failing to
+ * fulfill this requirement may cause toByteArray() to return incomplete
+ * contents.
+ *
+ * @severity warning
+ */
+ByteArrayOutputStream_FlushBeforeRetrieve(ByteArrayOutputStream b, OutputStream o) {
+	creation event outputstreaminit after(ByteArrayOutputStream b) returning(OutputStream o) :
+		call(OutputStream+.new(..)) && args(b, ..) {
+		}
+	event write before(OutputStream o) : call(* OutputStream+.write*(..)) && target(o) {
+	}
+	event flush before(OutputStream o) : call(* OutputStream+.flush(..)) && target(o) {
+	}
+	event close before(OutputStream o) : call(* OutputStream+.close(..)) && target(o) {
+	}
+	event tobytearray before(ByteArrayOutputStream b) :
+		call(* ByteArrayOutputStream+.toByteArray(..)) && target(b) {
+		}
+	event tostring before(ByteArrayOutputStream b) :
+		call(* ByteArrayOutputStream+.toString(..)) && target(b) {
+		}
+
+	fsm :
+		initial [
+			outputstreaminit -> outputstreamcreated
+		]
+		outputstreamcreated [
+			write -> writing
+			flush -> flushed
+			close -> closed
+		]
+		writing [
+			write -> writing
+			flush -> flushed
+			close -> closed
+		]
+		flushed [
+			flush -> flushed
+			write -> writing
+			tobytearray -> flushed
+			tostring -> flushed
+			close -> closed
+		]
+		closed [
+			tobytearray -> closed
+			tostring -> closed
+		]
+
+	@fail {
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "flush() or close() should be invoked before toByteArray() or toString() to get the complete contents." + __LOC);
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/Byte_BadDecodeArg.mop
+++ b/scripts/javamop-agent-bundle/props/Byte_BadDecodeArg.mop
@@ -1,0 +1,67 @@
+package mop;
+
+import java.io.*;
+import java.lang.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns when the argument to decode is wrong
+ *
+ * According to the manual, the argument cannot contain any whitespace.
+ * Also, there is a format to follow. 
+ * http://docs.oracle.com/javase/6/docs/api/java/lang/Byte.html#decode%28java.lang.String%29
+ *
+ * @severity error
+ */
+Byte_BadDecodeArg() {
+
+	event decode before(Byte b, String nm) : 
+		call(* Byte.decode(String)) && target(b) && args(nm) {
+		if (nm == null || nm.length() == 0) {
+			RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+			RVMLogging.out.println(Level.CRITICAL, "Wrong argument to Byte.decode(String nm)");
+		} else {
+			// whitespace check
+			for (int j = 0; j < nm.length(); j++) {
+				if (Character.isWhitespace(nm.charAt(j))) {
+					RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+					RVMLogging.out.println(Level.CRITICAL, "Wrong argument to Byte.decode(String nm)");
+				}
+			}
+
+			// formatcheck
+			String sub;
+			if (nm.charAt(0) == '-') {
+				sub = nm.substring(1);
+			} else {
+				sub = nm;
+			}
+
+			int radix = 0;
+			if (sub.startsWith("0x") || sub.startsWith("0X")) {
+				sub = sub.substring(2);
+				radix = 16;
+			} else if (sub.startsWith("#")) {
+				sub = sub.substring(1);
+				radix = 16;
+			} else if (sub.startsWith("0")) {
+				sub = sub.substring(1);
+				radix = 8;
+			} else {
+				radix = 10;
+			}
+
+			try {
+				if (Byte.parseByte(sub, radix) < 0) {
+					RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+					RVMLogging.out.println(Level.CRITICAL, "Wrong argument to Byte.decode(String nm)");
+				}
+			} catch (Exception e) {
+				RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+				RVMLogging.out.println(Level.CRITICAL, "Wrong argument to Byte.decode(String nm)");
+			}
+		}
+    }
+}
+

--- a/scripts/javamop-agent-bundle/props/Byte_BadParsingArgs.mop
+++ b/scripts/javamop-agent-bundle/props/Byte_BadParsingArgs.mop
@@ -1,0 +1,55 @@
+package mop;
+
+import java.io.*;
+import java.lang.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns when arguments to parseByte are wrong.
+ *
+ * According to the manual, the first argument cannot be null or of length zero.
+ * Also, radix should be in the range.
+ * http://docs.oracle.com/javase/6/docs/api/java/lang/Byte.html#parseByte%28java.lang.String,%20int%29
+ *
+ * @severity warning
+ */
+Byte_BadParsingArgs() {
+    event bad_arg before(String s, int radix) : 
+        call(* Byte.parseByte(String, int)) && args(s, radix) {
+        if(s == null || s.length() == 0){
+         RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+        	RVMLogging.out.println(Level.CRITICAL, "Wrong argument to Byte.parseByte(String s, int radix)");
+        } else if(radix < java.lang.Character.MIN_RADIX || radix > java.lang.Character.MAX_RADIX){
+         RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+        	RVMLogging.out.println(Level.CRITICAL, "Wrong argument to Byte.parseByte(String s, int radix)");
+        } else {
+            for(int j = 0; j < s.length(); j++){
+                if(Character.digit(s.charAt(j), radix) == -1){
+                    if(!(j == 0 && s.length() > 1 && s.charAt(0) == '-')){
+                        RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+                        RVMLogging.out.println(Level.CRITICAL, "Wrong argument to Byte.parseByte(String s, int radix)");
+                    }
+                } 
+            }
+        }
+    }
+    
+    event bad_arg2 before(String s) : 
+        call(* Byte.parseByte(String)) && args(s) {
+        if(s == null || s.length() == 0){
+         RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+        	RVMLogging.out.println(Level.CRITICAL, "Wrong argument to Byte.parseByte(String s)");
+        } else {
+            for(int j = 0; j < s.length(); j++){
+                if(Character.digit(s.charAt(j), 10) == -1){
+                    if(!(j == 0 && s.length() > 1 && s.charAt(0) == '-')){
+                        RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+                        RVMLogging.out.println(Level.CRITICAL, "Wrong argument to Byte.parseByte(String s)");
+                    }
+                } 
+            }
+        }
+    }
+}
+

--- a/scripts/javamop-agent-bundle/props/CharSequence_NotInMap.mop
+++ b/scripts/javamop-agent-bundle/props/CharSequence_NotInMap.mop
@@ -1,0 +1,41 @@
+package mop;
+
+import java.io.*;
+import java.lang.*;
+import java.nio.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if one tries to add a CharSequence object into a map as a key.
+ * 
+ * According to the manual, this inferface does not refine the general contracts of the
+ * equals and hashCode methods. Therefore, it might not be safe to use CharSequence instances
+ * as elements in a set
+ * http://docs.oracle.com/javase/6/docs/api/java/lang/CharSequence.html
+ * User should check whether the instance of CharSequence that he/she tries to use supports
+ * those methods.
+ * 
+ * @severity warning
+ */
+
+CharSequence_NotInMap(Map map) {
+	boolean flag = false;
+
+	event map_put before(Map map) : call(* Map+.put(..)) && target(map) && args(CharSequence, ..) && !args(String, ..) && !args(CharBuffer, ..)
+		&& condition(!flag){
+			flag = true;
+			RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+			RVMLogging.out.println(Level.CRITICAL, "It might not be safe to add a CharSequence instance into a map as a key"); 
+		}
+
+	event map_putall before(Map map, Map m) : call(* Map+.putAll(Map)) && args(m) && target(map) && condition(!flag) {
+			for(Object o : m.keySet()){
+				if(o instanceof CharSequence && !(o instanceof String) && !(o instanceof CharBuffer)){
+					flag = true;
+					RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+					RVMLogging.out.println(Level.CRITICAL, "It might not be safe to add a CharSequence instance into a map as a key");
+				}
+			} 
+		}
+}

--- a/scripts/javamop-agent-bundle/props/CharSequence_NotInSet.mop
+++ b/scripts/javamop-agent-bundle/props/CharSequence_NotInSet.mop
@@ -1,0 +1,41 @@
+package mop;
+
+import java.io.*;
+import java.lang.*;
+import java.nio.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if one tries to add a CharSequence object into a set.
+ * 
+ * According to the manual, this inferface does not refine the general contracts of the
+ * equals and hashCode methods. Therefore, it might not be safe to use CharSequence instances
+ * as elements in a set
+ * http://docs.oracle.com/javase/6/docs/api/java/lang/CharSequence.html
+ * User should check whether the instance of CharSequence that he/she tries to use supports
+ * those methods.
+ * 
+ * @severity warning
+ */
+
+CharSequence_NotInSet() {
+	boolean flag = false;
+	
+	event set_add before() : call(* Set+.add(..)) && args(CharSequence) && !args(String) && !args(CharBuffer) && condition(!flag){
+		flag = true;
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "It might not be safe to add a CharSequence instance into a set"); 
+	}
+
+	event set_addall before(Collection c) : call(* Set+.addAll(Collection)) && args(c) && condition(!flag){
+		for(Object o : c){
+			if(o instanceof CharSequence && !(o instanceof String) && !(o instanceof CharBuffer)){
+				flag = true;
+				RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+				RVMLogging.out.println(Level.CRITICAL, "It might not be safe to add a CharSequence instance into a set");
+			}
+		} 
+	}
+	
+}

--- a/scripts/javamop-agent-bundle/props/CharSequence_UndefinedHashCode.mop
+++ b/scripts/javamop-agent-bundle/props/CharSequence_UndefinedHashCode.mop
@@ -1,0 +1,31 @@
+package mop;
+
+import java.io.*;
+import java.lang.*;
+import java.nio.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if one tries to use equals or hashCode method of a CharSequence instance.  
+ * 
+ * According to the manual, this inferface does not refine the general contracts of the
+ * equals and hashCode methods.
+ * http://docs.oracle.com/javase/6/docs/api/java/lang/CharSequence.html
+ * User should check whether the instance of CharSequence that he/she tries to use supports
+ * those methods.
+ * 
+ * @severity warning
+ */
+
+CharSequence_UndefinedHashCode() {
+	event equals before() : call(* CharSequence+.equals(..)) && !target(String) && !target(CharBuffer){
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "equals and hashCode methods might not be supported in CharSequence"); 
+	}
+	
+	event hashCode before() : call(* CharSequence+.hashCode(..)) && !target(String) && !target(CharBuffer){
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "equals and hashCode methods might not be supported in CharSequence"); 
+	}
+}

--- a/scripts/javamop-agent-bundle/props/Character_ValidateChar.mop
+++ b/scripts/javamop-agent-bundle/props/Character_ValidateChar.mop
@@ -1,0 +1,36 @@
+package mop;
+
+import java.io.*;
+import java.lang.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Suggests if invalid code point or surrogate pair is used in charCount(..) or toCodePoint(..)
+ *
+ * According to the manual, those methods don't validate input.
+ * User should do this before using methods.  
+ * http://docs.oracle.com/javase/6/docs/api/java/lang/Character.html#charCount%28int%29
+ * http://docs.oracle.com/javase/6/docs/api/java/lang/Character.html#toCodePoint%28char,%20char%29
+ *
+ * @severity warning
+ */
+ 
+Character_ValidateChar() {
+    event charCount before(int codePoint): 
+        call(* Character.charCount(int)) && args(codePoint) {
+            if(!Character.isValidCodePoint(codePoint)){
+                RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+                RVMLogging.out.println(Level.CRITICAL, "The code point used in charCount(int codePoint) is not valid.");
+            }
+        }
+
+    event toCodePoint before(char high, char low): 
+        call(* Character.toCodePoint(char, char)) && args(high, low) {
+            if(!Character.isSurrogatePair(high, low)){
+                RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+                RVMLogging.out.println(Level.CRITICAL, "The surrogate pair used in toCodePoint(char high, char low) is not valid.");
+            }
+        }
+}
+

--- a/scripts/javamop-agent-bundle/props/ClassLoader_UnsafeClassDefinition.mop
+++ b/scripts/javamop-agent-bundle/props/ClassLoader_UnsafeClassDefinition.mop
@@ -1,0 +1,26 @@
+package mop;
+
+import java.io.*;
+import java.lang.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ *
+ * Warns if one tries to define a class whose name starts with "java."
+ *
+ * According to the manual, for security reasons, one cannot define a class whose name
+ * starts with "java." outside of the bootstrap class loader. 
+ * http://docs.oracle.com/javase/6/docs/api/java/lang/ClassLoader.html#defineClass%28java.lang.String,%20byte[],%20int,%20int,%20java.security.ProtectionDomain%29
+ *
+ * @severity error
+ */
+ClassLoader_UnsafeClassDefinition() {
+	event defineClass before(String name) :
+		call(* ClassLoader+.defineClass(String, ..)) && args(name, ..) && condition(name.startsWith("java.")){
+			RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+			RVMLogging.out.println(Level.CRITICAL, "An invalid binary name is used");
+		}
+}
+
+

--- a/scripts/javamop-agent-bundle/props/Closeable_MeaninglessClose.mop
+++ b/scripts/javamop-agent-bundle/props/Closeable_MeaninglessClose.mop
@@ -1,0 +1,40 @@
+package mop;
+
+import java.io.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if meaningless close() is invoked.
+ *
+ * In several classes, close(), specified in Closeable interface, has no
+ * effect and other methods in those classes can be called after close()
+ * without IOException. In OpenJDK 6's java.io package, the following classes
+ * have such meaningless close():
+ *  ByteArrayInputSteram
+ *   http://download.oracle.com/javase/6/docs/api/java/io/ByteArrayInputStream.html#close()
+ *  ByteArrayOutputStream
+ *   http://download.oracle.com/javase/6/docs/api/java/io/ByteArrayOutputStream.html#close()
+ *  CharArrayWriter
+ *   http://download.oracle.com/javase/6/docs/api/java/io/CharArrayWriter.html#close%28%29
+ *  StringWriter
+ *   http://download.oracle.com/javase/6/docs/api/java/io/StringWriter.html#close%28%29
+ *
+ * This specification warns when such meaningless close() is invoked, in the
+ * hope that it helps the user to understand the actual behavior.
+ *
+ * @severity suggestion
+ */
+Closeable_MeaninglessClose() {
+	event close before() : call(* Closeable+.close()) &&
+		(
+			target(ByteArrayInputStream) ||
+			target(ByteArrayOutputStream) ||
+			target(CharArrayWriter) ||
+			target(StringWriter)
+		) {
+			RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+			RVMLogging.out.println(Level.CRITICAL, "close() has no effect.");
+		}
+
+}

--- a/scripts/javamop-agent-bundle/props/Closeable_MultipleClose.mop
+++ b/scripts/javamop-agent-bundle/props/Closeable_MultipleClose.mop
@@ -1,0 +1,31 @@
+package mop;
+
+import java.io.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if close() is invoked multiple times.
+ *
+ * According to the Closeable.close() documentation, closing a previously closed
+ * stream has no effect.
+ * http://download.oracle.com/javase/6/docs/api/java/io/Closeable.html#close%28%29
+ *
+ * Although calling close() multiple times does not do any harm, this property
+ * raises a warning in the hope that the warning helps developers to find a
+ * glitch in their programs.
+ *
+ * @severity suggestion
+ */
+
+Closeable_MultipleClose(Closeable c) {
+	event close before(Closeable c) : call(* Closeable+.close(..)) && target(c) {}
+
+	ere : close close+
+
+	@match {
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "close() was invoked multiple times.");
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/Collection_HashCode.mop
+++ b/scripts/javamop-agent-bundle/props/Collection_HashCode.mop
@@ -1,0 +1,46 @@
+package mop;
+
+import java.util.*;
+import java.lang.reflect.*;
+import org.aspectj.lang.Signature;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if equals() is overriden but hashCode() is not.
+ *
+ * The general contract for hashCode() is that any class that overrides
+ * Object.equals() must also overrides Object.hashCode().
+ * http://docs.oracle.com/javase/6/docs/api/java/util/Collection.html#hashCode%28%29
+ *
+ * The Collection interface does not add any stipulation to the above general
+ * contract. This property warns if a subclass of Collection overrides
+ * equals() but does not override hashCode().
+ *
+ * @severity error
+ */
+
+Collection_HashCode() {
+	event staticinit after() : staticinitialization(Collection+) {
+		Signature initsig = __STATICSIG;
+		Class klass = initsig.getDeclaringType();		
+
+		if (klass != null) {
+			Method equalsmethod = null;
+			Method hashcodemethod = null;
+
+			try {
+				equalsmethod = klass.getDeclaredMethod("equals", Object.class);
+				hashcodemethod = klass.getDeclaredMethod("hashCode", (Class[]) null);
+			}
+			catch (NoSuchMethodException e) {
+			}
+
+			if (equalsmethod != null && hashcodemethod == null) {
+				RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+				RVMLogging.out.println(Level.CRITICAL, klass.getName() + " overrides equals() but does not override hashCode().");
+			}
+		}
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/Collection_UnsafeIterator.mop
+++ b/scripts/javamop-agent-bundle/props/Collection_UnsafeIterator.mop
@@ -1,0 +1,52 @@
+package mop;
+
+import java.util.*;
+import java.lang.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if a collection is modified while an iterator is being used.
+ *
+ * It is not generally permissible to modify a Collection while iterating over
+ * it. Some Iterators implementations may choose to throw
+ * ConcurrentModificationException if this behavior is detected, but this
+ * fail-fast behavior is not guaranteed.
+ * http://docs.oracle.com/javase/6/docs/api/java/util/ConcurrentModificationException.html
+ *
+ * This property warns if a collection is modified while an iterator is being
+ * used. Unlike the underlying system, where the fail-fast behavior is not
+ * guaranteed, this property always detects the problematic behavior.
+ *
+ * @severity error
+ */
+
+Collection_UnsafeIterator(Collection c, Iterator i) {
+	creation event create after(Collection c) returning(Iterator i) :
+		call(Iterator Iterable+.iterator()) && target(c) {}
+
+	event modify before(Collection c) :
+		(
+			call(* Collection+.add*(..)) ||
+			call(* Collection+.clear(..)) ||
+			call(* Collection+.offer*(..)) ||
+			call(* Collection+.pop(..)) ||
+			call(* Collection+.push(..)) ||
+			call(* Collection+.remove*(..)) ||
+			call(* Collection+.retain*(..))
+		) && target(c) {}
+
+	event useiter before(Iterator i) :
+		(
+			call(* Iterator.hasNext(..)) ||
+			call(* Iterator.next(..))
+		) && target(i) {}
+
+	ere : create useiter* modify+ useiter
+
+	@match {
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "The collection was modified while an iterator is being used.");
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/Collection_UnsynchronizedAddAll.mop
+++ b/scripts/javamop-agent-bundle/props/Collection_UnsynchronizedAddAll.mop
@@ -1,0 +1,44 @@
+package mop;
+
+import java.util.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if the source collection is modified while Collection.addAll() is
+ * running.
+ *
+ * The behavior of Collection.addAll() is undefined if the specified source
+ * collection is modified while the operation is in progress.
+ * http://docs.oracle.com/javase/6/docs/api/java/util/Collection.html#addAll%28java.util.Collection%29
+ *
+ * This property assumes that addAll() of all Collection and its subclasses
+ * behave similarly, and warns if add*(), remove*(), clear() or retain*() is
+ * called on the collection that is passed to addAll() as an argument.
+ *
+ * @severity error
+ */
+
+Collection_UnsynchronizedAddAll(Collection t, Collection s) {
+	creation event enter before(Collection t, Collection s) :
+		call(boolean Collection+.addAll(..)) && target(t) && args(s) {}
+
+	event modify before(Collection s) :
+		(
+			call(* Collection+.add*(..)) ||
+			call(* Collection+.remove*(..)) ||
+			call(* Collection+.clear(..)) ||
+			call(* Collection+.retain*(..))
+		) && target(s) {}
+
+	event leave after(Collection t, Collection s) :
+		call(boolean Collection+.addAll(..)) && target(t) && args(s) {}
+
+	ere : (enter leave modify*)*
+
+	@fail {
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "The source collection of addAll() has been modified.");
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/Collections_Comparable.mop
+++ b/scripts/javamop-agent-bundle/props/Collections_Comparable.mop
@@ -1,0 +1,59 @@
+package mop;
+
+import java.util.*;
+import java.lang.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if the argument of Collections.sort(List<T>, Comparator) is not comparable.
+ *
+ * All elements in the argument of Collections.sort(List<T>, Comparator) must
+ * be mutually comparable.
+ * http://docs.oracle.com/javase/6/docs/api/java/util/Collections.html#sort%28java.util.List%29
+ *
+ * Similarly, the argument of Collections.min(Collectio<T>, Comparator) and
+ * Collections.max(Collection<T>, Comparator) must satisfy the requirement.
+ * http://docs.oracle.com/javase/6/docs/api/java/util/Collections.html#min%28java.util.Collection,%20java.util.Comparator%29
+ * http://docs.oracle.com/javase/6/docs/api/java/util/Collections.html#max%28java.util.Collection,%20java.util.Comparator%29
+ *
+ * This property verifies that comparing each pair of elements does not raise
+ * a ClassCastException. This property requires O(n^2) time for n elements.
+ *
+ * @severity error
+ */
+
+Collections_Comparable() {
+	private void validate(Object[] arr, Comparator comp, String msg)
+	{
+		for (int i = 0; i < arr.length; ++i) {
+			Object o1 = arr[i];
+
+			for (int j = i + 1; j < arr.length; ++j) {
+				Object o2 = arr[j];
+				try {
+					comp.compare(o1, o2);
+					comp.compare(o2, o1);
+				}
+				catch (ClassCastException e) {
+					RVMLogging.out.println(Level.CRITICAL, msg);
+					RVMLogging.out.println(Level.CRITICAL, i + "-th element and " + j + "-th element are not comparable.");
+				}
+			}
+		}
+	}
+
+	event invalid_sort before(List list, Comparator comp) :
+		call(void Collections.sort(List, Comparator)) && args(list, comp) {
+		this.validate(list.toArray(), comp, __DEFAULT_MESSAGE);
+	}
+
+	event invalid_minmax before(Collection col, Comparator comp) :
+		(
+			call(* Collections.min(Collection, Comparator)) ||
+			call(* Collections.max(Collection, Comparator))
+		) && args(col, comp) {
+		this.validate(col.toArray(), comp, __DEFAULT_MESSAGE);
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/Collections_CopySize.mop
+++ b/scripts/javamop-agent-bundle/props/Collections_CopySize.mop
@@ -1,0 +1,28 @@
+package mop;
+
+import java.util.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if the destination list of Arrays.copy() is not as long as the source
+ * list.
+ *
+ * Collections.copy() requires that the destination list be as long as the
+ * source list.
+ * http://docs.oracle.com/javase/6/docs/api/java/util/Collections.html#copy%28java.util.List,%20java.util.List%29
+ *
+ * This property checks the lengths of two lists.
+ *
+ * @severity error
+ */
+
+Collections_CopySize() {
+	event bad_copy before(List dest, List src) :
+		call(void Collections.copy(List, List)) && args(dest, src) &&
+		condition(dest.size() < src.size()) {
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "The destination list must be at least as long as the source list.");
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/Collections_ImplementComparable.mop
+++ b/scripts/javamop-agent-bundle/props/Collections_ImplementComparable.mop
@@ -1,0 +1,67 @@
+package mop;
+
+import java.util.*;
+import java.lang.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if the argument of Collections.sort(List<T>) is not comparable.
+ *
+ * All elements in the argument of Collections.sort(List<T>) must implement
+ * the Comparable interface, and they must be mutually comparable.
+ * http://docs.oracle.com/javase/6/docs/api/java/util/Collections.html#sort%28java.util.List%29
+ *
+ * Similarly, the argument of Collections.min(Collection<T>) and
+ * Collections.max(Collection<T>) must satisfy the same requirements.
+ * http://docs.oracle.com/javase/6/docs/api/java/util/Collections.html#min%28java.util.Collection%29
+ * http://docs.oracle.com/javase/6/docs/api/java/util/Collections.html#max%28java.util.Collection%29
+ *
+ * This property verifies that each element implements the Comparable
+ * interface, and if comparing each pair of elements does not raise a
+ * ClassCastException. This property requires O(n^2) time for n elements.
+ *
+ * @severity error
+ */
+
+Collections_ImplementComparable() {
+	private void validate(Object[] arr, String msg)
+	{
+		for (int i = 0; i < arr.length; ++i) {
+			// Each element must implement the Comparable interface.
+			Object o1 = arr[i];
+			if (!(o1 instanceof Comparable)) {
+				RVMLogging.out.println(Level.CRITICAL, msg);
+				RVMLogging.out.println(Level.CRITICAL, i + "-th element does not implement the Comparable interface.");
+			}
+			Comparable c1 = (Comparable)o1;
+
+			// All elements must be mutually comparable.
+			for (int j = i + 1; j < arr.length; ++j) {
+				try {
+					Comparable c2 = (Comparable)arr[j];
+					c1.compareTo(c2);
+					c2.compareTo(c1);
+				}
+				catch (ClassCastException e) {
+					RVMLogging.out.println(Level.CRITICAL, msg);
+					RVMLogging.out.println(Level.CRITICAL, i + "-th element and " + j + "-th element are not comparable.");
+				}
+			}
+		}
+	}
+
+	event invalid_sort before(List list) :
+		call(void Collections.sort(List)) && args(list) {
+		this.validate(list.toArray(), __DEFAULT_MESSAGE);
+	}
+
+	event invalid_minmax before(Collection col) :
+		(
+			call(* Collections.min(Collection)) ||
+			call(* Collections.max(Collection))
+		) && args(col) {
+		this.validate(col.toArray(), __DEFAULT_MESSAGE);
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/Collections_NewSetFromMap.mop
+++ b/scripts/javamop-agent-bundle/props/Collections_NewSetFromMap.mop
@@ -1,0 +1,37 @@
+package mop;
+
+import java.util.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if the map passed to Collections.newSetFromMap() is either non-empty,
+ * or empty but directly accessed after the method returns.
+ *
+ * The specified map must be empty at the time Collections.newSetFromMap() is
+ * invoked, and should not be accessed directly after this method returns.
+ * http://docs.oracle.com/javase/6/docs/api/java/util/Collections.html#newSetFromMap%28java.util.Map%29
+ *
+ * @severity error
+ */
+
+Collections_NewSetFromMap(Map map) {
+	creation event create before(Map map) :
+		call(* Collections.newSetFromMap(Map)) && args(map) &&
+		condition(map.size() == 0) {}
+
+	creation event bad_create before(Map map) :
+		call(* Collections.newSetFromMap(Map)) && args(map) &&
+		condition(map.size() > 0) {}
+
+	event access before(Map map) :
+		call(* Map+.*(..)) && target(map) {}
+
+	ere : bad_create | (create access)
+
+	@match {
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "The map used in Collections.newSetFromMap() must be empty before calling this method, and should not be accessed directly after this method returns.");
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/Collections_SortBeforeBinarySearch.mop
+++ b/scripts/javamop-agent-bundle/props/Collections_SortBeforeBinarySearch.mop
@@ -1,0 +1,75 @@
+package mop;
+
+import java.util.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if binarySearch() is invoked on an unsorted list.
+ *
+ * Before calling binarySearch(), the list must be sorted into ascending
+ * order.
+ * http://docs.oracle.com/javase/6/docs/api/java/util/Collections.html#binarySearch%28java.util.List,%20T%29
+ *
+ * This property verifies that sort() is invoked before calling
+ * binarySearch(), and no modifications are applied in between two calls.
+ *
+ * Since a list can be sorted without using sort(), this property may report a
+ * false warning.
+ *
+ * @severity error
+ */
+
+Collections_SortBeforeBinarySearch(List list) {
+	Comparator comp = null;
+
+	event sort1 before(List list) :
+		call(void Collections.sort(List)) && args(list) {}
+	event sort2 before(List list, Comparator comp2) :
+		call(void Collections.sort(List, Comparator)) && args(list, comp2) {
+		this.comp = comp2;
+	}
+
+	event modify before(List list) :
+		(
+			call(* Collection+.add*(..)) ||
+			call(* Collection+.remove*(..)) ||
+			call(* Collection+.clear(..)) ||
+			call(* Collection+.retain*(..)) ||
+			call(* List+.set(..))
+		) && target(list) {}
+
+	event bsearch1 before(List list) :
+		call(int Collections.binarySearch(List, Object)) && args(list, ..) {}
+	event bsearch2 before(List list, Comparator comp2) :
+		call(int Collections.binarySearch(List, Object, Comparator)) && args(list, .., comp2) &&
+		condition(this.comp == comp2) {}
+	event bad_bsearch2 before(List list, Comparator comp2) :
+		call(int Collections.binarySearch(List, Object, Comparator)) && args(list, .., comp2) &&
+		condition(this.comp != comp2) {}
+
+	fsm :
+		unsorted [
+			sort1 -> sorted1
+			sort2 -> sorted2
+			modify -> unsorted
+		]
+		sorted1 [
+			sort1 -> sorted1
+			sort2 -> sorted2
+			modify -> unsorted
+			bsearch1 -> sorted1
+		]
+		sorted2 [
+			sort1 -> sorted1
+			sort2 -> sorted2
+			modify -> unsorted
+			bsearch2 -> sorted2
+		]
+
+	@fail {
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "The list must be sorted prior to making binarySearch() call.");
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/Collections_SynchronizedCollection.mop
+++ b/scripts/javamop-agent-bundle/props/Collections_SynchronizedCollection.mop
@@ -1,0 +1,53 @@
+package mop;
+
+import java.util.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if a synchronized collection is accessed in an unsynchronized manner.
+ *
+ * According to the manual, it is imperative that the user manually
+ * synchronize on the returned collection when iterating over it.
+ * http://docs.oracle.com/javase/6/docs/api/java/util/Collections.html#synchronizedCollection%28java.util.Collection%29
+ *
+ * This property is designed to match a case where either a collection is
+ * synchronized and an non-synchronized iterator is created for the
+ * collection, or a synchronized iterator is created, but accessed in an
+ * unsynchronized manner.
+ *
+ * @severity error
+ */
+
+Collections_SynchronizedCollection(Collection col, Iterator iter) {
+	Collection col;
+
+	creation event sync after() returning(Collection col) : 
+		call(* Collections.synchronizedCollection(Collection)) ||
+		call(* Collections.synchronizedSet(Set)) ||
+		call(* Collections.synchronizedSortedSet(SortedSet)) ||
+		call(* Collections.synchronizedList(List))
+	{
+		this.col = col;
+	}
+
+	event syncCreateIter after(Collection col) returning(Iterator iter) : 
+		call(* Collection+.iterator()) && target(col) &&
+		condition(Thread.holdsLock(col)) {}
+
+	event asyncCreateIter after(Collection col) returning(Iterator iter) : 
+		call(* Collection+.iterator()) && target(col) &&
+		condition(!Thread.holdsLock(col)) {}
+
+	event accessIter before(Iterator iter) : 
+		call(* Iterator.*(..)) && target(iter) &&
+		condition(!Thread.holdsLock(this.col)) {}
+
+	ere : (sync asyncCreateIter) | (sync syncCreateIter accessIter)
+
+	@match {
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "A synchronized collection was accessed in a thread-unsafe manner.");
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/Collections_SynchronizedMap.mop
+++ b/scripts/javamop-agent-bundle/props/Collections_SynchronizedMap.mop
@@ -1,0 +1,59 @@
+package mop;
+
+import java.io.*;
+import java.util.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if a synchronized collection is accessed in an unsynchronized manner.
+ *
+ * According to the manual, it is imperative that the user manually
+ * synchronize on the returned map when iterating over its collection views.
+ * http://docs.oracle.com/javase/6/docs/api/java/util/Collections.html#synchronizedMap%28java.util.Map%29
+ *
+ * This property is designed to match a case where either a map is
+ * synchronized and an non-synchronized iterator is created for the map, or a
+ * synchronized iterator is created, but accessed in an unsynchronized manner.
+ * The difference from Collections_SynchronizedCollection is that a set must
+ * be created from the synchronized map.
+ *
+ * @severity error
+ */
+
+Collections_SynchronizedMap(Map syncMap, Collection col, Iterator iter) {
+	Map map;
+	creation event sync after() returning(Map syncMap) : 
+		call(* Collections.synchronizedMap(Map)) ||
+		call(* Collections.synchronizedSortedMap(SortedMap))
+	{
+		this.map = syncMap;
+	}
+
+	event createSet after(Map syncMap) returning(Collection col) : 
+		(
+			call(Set Map+.keySet()) ||
+			call(Set Map+.entrySet()) ||
+			call(Collection Map+.values())
+		) && target(syncMap) {}
+
+	event syncCreateIter after(Collection col) returning(Iterator iter) : 
+		call(* Collection+.iterator()) && target(col) &&
+		condition(Thread.holdsLock(map)) {}
+
+	event asyncCreateIter after(Collection col) returning(Iterator iter) : 
+		call(* Collection+.iterator()) && target(col) &&
+		condition(!Thread.holdsLock(map)) {}
+
+	event accessIter before(Iterator iter) : 
+		call(* Iterator.*(..)) && target(iter) &&
+		condition(!Thread.holdsLock(map)) {}
+
+	ere : sync createSet (asyncCreateIter | (syncCreateIter accessIter))
+
+	@match {
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "A collection view of a synchronized map was accessed in a thread-unsafe manner.");
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/Collections_UnnecessaryNewSetFromMap.mop
+++ b/scripts/javamop-agent-bundle/props/Collections_UnnecessaryNewSetFromMap.mop
@@ -1,0 +1,33 @@
+package mop;
+
+import java.util.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if Collections.newSetFromMap() is invoked on HashMap or TreeMap.
+ *
+ * There is no need to use Collections.newSetFromMap() on a Map implementation
+ * that already has a corresponding Set imeplementation (such as HashMap or
+ * TreeMap).
+ * http://docs.oracle.com/javase/6/docs/api/java/util/Collections.html#newSetFromMap%28java.util.Map%29
+ *
+ * This property warns if newSetFromMap() is invoked on either HashMap or
+ * TreeMap. Since calling newSetFromMap() does not do any harm, a violation is
+ * merely suggestive.
+ *
+ * @severity suggestion
+ */
+
+Collections_UnnecessaryNewSetFromMap() {
+	event unnecessary before() :
+		call(* Collections.newSetFromMap(Map)) &&
+		(
+			args(HashMap) ||
+			args(TreeMap)
+		) {
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "There is no need to use Collections.newSetFromMap() on HashMap or TreeMap.");
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/Comparable_CompareToNull.mop
+++ b/scripts/javamop-agent-bundle/props/Comparable_CompareToNull.mop
@@ -1,0 +1,22 @@
+package mop;
+
+import java.io.*;
+import java.lang.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if a comparable object is compared to null.
+ * 
+ * According to the manual, null is not an instance of any class; it cannot be compared to any object. 
+ * http://docs.oracle.com/javase/6/docs/api/java/lang/Comparable.html#compareTo%28T%29
+ * 
+ * @severity error
+ */
+
+Comparable_CompareToNull() {
+	event nullcompare before(Object o) : call(* Comparable+.compareTo(..)) && args(o) && if(o == null) {
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "null cannot be compared to any object");
+	}
+}

--- a/scripts/javamop-agent-bundle/props/Comparable_CompareToNullException.mop
+++ b/scripts/javamop-agent-bundle/props/Comparable_CompareToNullException.mop
@@ -1,0 +1,29 @@
+package mop;
+
+import java.io.*;
+import java.lang.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if a comparable object does not throw a NullPointerException when compared to null.
+ * 
+ * According to the manual, compareTo(null) should throw a NullPointerException. 
+ * http://docs.oracle.com/javase/6/docs/api/java/lang/Comparable.html#compareTo%28T%29
+ * 
+ * @severity error
+ */
+
+Comparable_CompareToNullException() {
+
+	event badexception after(Object o) throwing(Exception e) : call(* Comparable+.compareTo(..)) 
+		&& args(o) && if(o == null) && condition(!(e instanceof NullPointerException)) {
+			RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+			RVMLogging.out.println(Level.CRITICAL, "NullPointerException should be thrown when an object is compared to null");
+		}
+	event badcompare after(Object o) returning(int i) : call(* Comparable+.compareTo(..)) 
+		&& args(o) && if(o == null) {
+			RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+			RVMLogging.out.println(Level.CRITICAL, "NullPointerException should be thrown when an object is compared to null");
+		}
+}

--- a/scripts/javamop-agent-bundle/props/Console_CloseReader.mop
+++ b/scripts/javamop-agent-bundle/props/Console_CloseReader.mop
@@ -1,0 +1,32 @@
+package mop;
+
+import java.io.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if close() is invoked on the object returned by Console.reader().
+ *
+ * Invoking close() on the objects returned by Console.reader() does not close
+ * the underlying streams.
+ * http://download.oracle.com/javase/6/docs/api/java/io/Console.html
+ *
+ * This specification warns if such useless invocation is detected.
+ *
+ * @severity suggestion
+ */
+
+Console_CloseReader(Reader r) {
+	event getreader after returning(Reader r) :
+		call(Reader+ Console+.reader()) {}
+	event close before(Reader r) :
+		call(* Reader+.close(..)) && target(r) {}
+
+	ere : getreader close+
+
+	@match {
+		RVMLogging.out.println(Level.WARNING, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.WARNING, "Invoking close() on the object returned by Console.reader() does not close the underlying stream.");
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/Console_CloseWriter.mop
+++ b/scripts/javamop-agent-bundle/props/Console_CloseWriter.mop
@@ -1,0 +1,32 @@
+package mop;
+
+import java.io.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if close() is invoked on the object returned by Console.writer().
+ *
+ * Invoking close() on the objects returned by Console.writer() does not close
+ * the underlying streams.
+ * http://download.oracle.com/javase/6/docs/api/java/io/Console.html
+ *
+ * This specification warns if such useless invocation is detected.
+ *
+ * @severity suggestion
+ */
+
+Console_CloseWriter(Writer w) {
+	event getwriter after returning(Writer w) :
+		call(Writer+ Console+.writer()) {}
+	event close before(Writer w) :
+		call(* Writer+.close(..)) && target(w) {}
+
+	ere : getwriter close+
+
+	@match {
+		RVMLogging.out.println(Level.WARNING, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.WARNING, "Invoking close() on the object returned by Console.writer() does not close the underlying stream.");
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/Console_FillZeroPassword.mop
+++ b/scripts/javamop-agent-bundle/props/Console_FillZeroPassword.mop
@@ -1,0 +1,38 @@
+package mop;
+
+import java.io.*;
+import java.util.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if an application reads a password but does not obliterate it.
+ *
+ * After reading a password from the console and using it, the application
+ * should manually zero the retrieved password to minimize the lifetime of
+ * sensitive data in memory.
+ * http://download.oracle.com/javase/6/docs/api/java/io/Console.html
+ *
+ * This specification warns if an application reads a password using
+ * Console.readPassword() but never zeroes it using Arrays.fill(). It may
+ * raise false alarms if the application zeroes the password buffer using
+ * other methods.
+ *
+ * @severity warning
+ */
+
+Console_FillZeroPassword(Object pwd) {
+	event read after() returning(Object pwd) :
+		call(char[] Console+.readPassword(..)) {}
+	event obliterate before(Object pwd) :
+		call(* Arrays.fill(char[], char)) && args(pwd, ..) {}
+	event endProg before() : endProgram() {}
+	
+	ltl : [](read => o obliterate)
+
+	@violation {
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "A password has never been obliterated.");
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/ContentHandler_GetContent.mop
+++ b/scripts/javamop-agent-bundle/props/ContentHandler_GetContent.mop
@@ -1,0 +1,29 @@
+package mop;
+
+import java.net.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if ContentHandler.getContent() is invoked.
+ *
+ * According to the reference, an application does not generally call the
+ * getContent() method in the ContentHandler class. Instead, an application
+ * calls the getContent() method in class URL or in URLConnection.
+ * http://docs.oracle.com/javase/6/docs/api/java/net/ContentHandler.html
+ *
+ * Since the reference was not clear about the consequence of calling
+ * ContentHandler.getContent(), a violation of this property is not considered
+ * an error.
+ *
+ * @severity suggestion
+ */
+ContentHandler_GetContent() {
+	event get_content before() : 
+		call(* ContentHandler+.getContent(..))
+	{
+		RVMLogging.out.println(Level.WARNING, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.WARNING, "An application does not generally call ContentHandler.getContent().");
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/DatagramPacket_Length.mop
+++ b/scripts/javamop-agent-bundle/props/DatagramPacket_Length.mop
@@ -1,0 +1,52 @@
+package mop;
+
+import java.net.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if a DatagramPacket object is constructed with a wrong length.
+ *
+ * According to the reference of DatagramPacket's constructors, the length
+ * parameter, which specifies the number of bytes to read, must be less than
+ * or equal to the length of buffer, another parameter of the constructors.
+ * http://docs.oracle.com/javase/6/docs/api/java/net/DatagramPacket.html#DatagramPacket%28byte[],%20int%29
+ *
+ * It is considered that the explanation of the length parameter is incorrect
+ * when a constructor takes an offset as another parameter. Unlike the
+ * reference, specifying length < buffer.length, this property warns if
+ * (offset + length) < buffer.length is violated, when offset is available.
+ *
+ * @severity error
+ */
+
+DatagramPacket_Length() {
+	void validateOffsetLength(byte[] buffer, int offset, int length, String msg) {
+		if (offset + length <= buffer.length)
+			return;
+
+		RVMLogging.out.println(Level.CRITICAL, msg);
+		RVMLogging.out.println(Level.CRITICAL, "The offset argument and/or the length argument are out of range; " + offset + " + " + length + " > " + buffer.length);
+	}
+
+	event construct_len before(byte[] buffer, int length) :
+		(
+			call(DatagramPacket.new(byte[], int)) ||
+			call(DatagramPacket.new(byte[], int, InetAddress, int)) ||
+			call(DatagramPacket.new(byte[], int, SocketAddress))
+		) && args(buffer, length, ..)
+	{
+		this.validateOffsetLength(buffer, 0, length, __DEFAULT_MESSAGE);
+	}
+
+	event construct_offlen before(byte[] buffer, int offset, int length) :
+		(
+			call(DatagramPacket.new(byte[], int, int)) ||
+			call(DatagramPacket.new(byte[], int, int, InetAddress, int)) ||
+			call(DatagramPacket.new(byte[], int, int, SocketAddress))
+		) && args(buffer, offset, length, ..)
+	{
+		this.validateOffsetLength(buffer, offset, length, __DEFAULT_MESSAGE);
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/DatagramPacket_SetLength.mop
+++ b/scripts/javamop-agent-bundle/props/DatagramPacket_SetLength.mop
@@ -1,0 +1,36 @@
+package mop;
+
+import java.net.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if DatagramPacket.setLength() is called with an invalid length.
+ *
+ * According to the reference of DatagramPacket.setLength(), the length, a
+ * parameter of DatagramPacket.setLength(), must be lesser or equal to the
+ * offset plus the length of the packet's buffer.
+ * http://docs.oracle.com/javase/6/docs/api/java/net/DatagramPacket.html#setLength%28int%29
+ *
+ * It is considered that the explanation is incorrect. It seems the offset
+ * plus the new length must be lesser or equal to the length of the packet's
+ * buffer. This property is based on this interpretation.
+ *
+ * @severity error
+ */
+
+DatagramPacket_SetLength() {
+	event setlength before(DatagramPacket packet, int length) :
+		call(void DatagramPacket.setLength(int)) && target(packet) && args(length)
+	{
+		int offset = packet.getOffset();
+		byte[] buffer = packet.getData();
+		if (length + offset <= buffer.length)
+			return;
+
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "The length argument is out of range; " + offset + " + " + length + " > " + buffer.length);
+	}
+}
+
+

--- a/scripts/javamop-agent-bundle/props/DatagramSocket_Port.mop
+++ b/scripts/javamop-agent-bundle/props/DatagramSocket_Port.mop
@@ -1,0 +1,31 @@
+package mop;
+
+import java.net.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if a DatagramSocket object is created with an invalid port.
+ *
+ * The local port, a parameter of some DatagramSocket's constructors, must be
+ * between 0 and 65535 inclusive.
+ * http://docs.oracle.com/javase/6/docs/api/java/net/DatagramSocket.html#DatagramSocket%28int,%20java.net.InetAddress%29
+ *
+ * @severity error
+ */
+
+DatagramSocket_Port() {
+	event construct_port before(int port) :
+		(
+			call(DatagramSocket.new(int)) ||
+			call(DatagramSocket.new(int, InetAddress))
+		) && args(port, ..)
+	{
+		if (0 <= port && port <= 65535)
+			return;
+
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "The specified port " + port + " is out of range; [0 ~ 65535]");
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/DatagramSocket_SoTimeout.mop
+++ b/scripts/javamop-agent-bundle/props/DatagramSocket_SoTimeout.mop
@@ -1,0 +1,28 @@
+package mop;
+
+import java.net.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if DatagramSocket.setSoTimeout() is called with an invalid timeout value.
+ *
+ * The timeout parameter of DatagramSocket.setSoTimeout() must be zero or
+ * greater than 0.
+ * http://docs.oracle.com/javase/6/docs/api/java/net/DatagramSocket.html#setSoTimeout%28int%29
+ *
+ * @severity error
+ */
+
+DatagramSocket_SoTimeout() {
+	event settimeout before(int timeout) :
+		call(void DatagramSocket.setSoTimeout(int)) && args(timeout)
+	{
+		if (timeout >= 0)
+			return;
+
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "The timeout value " + timeout + " is out of range; [0 ~ ]");
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/DatagramSocket_TrafficClass.mop
+++ b/scripts/javamop-agent-bundle/props/DatagramSocket_TrafficClass.mop
@@ -1,0 +1,54 @@
+package mop;
+
+import java.net.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if DatagramSocket.setTrafficClass() is called with an invalid traffic
+ * class value.
+ *
+ * The traffic class value, the only parameter of
+ * DatagramSocket.setTrafficClass(), must be between 0 and 255 inclusive.
+ * http://docs.oracle.com/javase/6/docs/api/java/net/DatagramSocket.html#setTrafficClass%28int%29
+ *
+ * According to the reference, when IPv4 is used, the last low order bit is
+ * always ignored and setting bits in the precedence field may result in a
+ * SocketException indicating that the operation is not permitted. To inform
+ * the user that some bits are ignored and may cause an error, this property
+ * warns if the last low bit or the precedence field is set.
+ *
+ * @severity error
+ */
+
+DatagramSocket_TrafficClass() {
+	event settc before(DatagramSocket socket, int tc) :
+		call(void DatagramSocket.setTrafficClass(int)) && target(socket) && args(tc)
+	{
+		boolean outofrange = !(0 <= tc && tc <= 255);
+		boolean mbz = false;
+		boolean precedence = false;
+
+		InetAddress addr = socket.getLocalAddress();
+		if (addr instanceof Inet4Address) {
+			mbz = (tc & 1) != 0 ? true : false;
+			precedence = (tc >> (4 + 1)) != 0;
+		}
+
+		if (outofrange || mbz || precedence) {
+			RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+			if (outofrange) {
+				RVMLogging.out.println(Level.CRITICAL, "The traffic class value " + tc + " is out of range; [0 ~ 255].");
+			}
+			else {
+				if (mbz) {
+					RVMLogging.out.println(Level.CRITICAL, "The traffic class value sets 1 to MBZ.");
+				}
+				if (precedence) {
+					RVMLogging.out.println(Level.CRITICAL, "The traffic class value sets non-zero precedence.");
+				}
+			}
+		}
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/Deque_OfferRatherThanAdd.mop
+++ b/scripts/javamop-agent-bundle/props/Deque_OfferRatherThanAdd.mop
@@ -1,0 +1,45 @@
+package mop;
+
+import java.util.*;
+import java.util.concurrent.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if a capacity-restricted deque performs a less preferable operation.
+ *
+ * According to the documentation, when using a capacity-restricted deque, it
+ * is generally preferable to use offerFirst(), offerLast() and offer()
+ * instead of addFirst(), addLast() and add(). Since push() is equivalent to
+ * addFirst(), push() is not perferable either.
+ * http://docs.oracle.com/javase/6/docs/api/java/util/Deque.html
+ *
+ * This property warns if addFirst(), addLast(), add() or push() is invoked on
+ * a capacity-restricted deque. Since there is no general way to detect whether
+ * or not a deque is capacity-restricted, this property warns only when the
+ * object is of LinkedBlockingDeque type and it is created with a specific
+ * capacity.
+ *
+ * @severity suggestion
+ */
+
+Deque_OfferRatherThanAdd(Deque q) {
+	creation event create after() returning(Deque q) :
+		call(LinkedBlockingDeque+.new(int)) {}
+
+	event add before(Deque q) :
+		(
+			call(* Deque+.addFirst(..)) ||
+			call(* Deque+.addLast(..)) ||
+			call(* Deque+.add(..)) ||
+			call(* Deque+.push(..))
+		) && target(q) {}
+
+	ere : create add+
+
+	@match {
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "When using a capacity-restricted deque, it is generally preferable to use offerFirst(), offerLast() and offer() instead of addFirt(), addLast() and add().");
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/Dictionary_NullKeyOrValue.mop
+++ b/scripts/javamop-agent-bundle/props/Dictionary_NullKeyOrValue.mop
@@ -1,0 +1,27 @@
+package mop;
+
+import java.util.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if null key or value is inserted into a Dictionary object.
+ *
+ * Neither the key nor the value can be null in a Dictionary object, according
+ * to the manual.
+ * http://docs.oracle.com/javase/6/docs/api/java/util/Dictionary.html#put%28K,%20V%29
+ *
+ * This property warns if such case is detected.
+ *
+ * @severity error
+ */
+
+Dictionary_NullKeyOrValue() {
+	event putnull before(Dictionary d, Object key, Object value) :
+		call(* Dictionary+.put(..)) && args(key, value) && target(d) &&
+		condition(key == null || value == null) {
+		RVMLogging.out.println(Level.WARNING, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.WARNING, "Dictionary allow neither null key nor null value.");
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/EnumMap_NonNull.mop
+++ b/scripts/javamop-agent-bundle/props/EnumMap_NonNull.mop
@@ -1,0 +1,34 @@
+package mop;
+
+import java.util.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if null is provided as a key of an EnumMap object.
+ *
+ * EnumMap does not permit null key.
+ * http://docs.oracle.com/javase/6/docs/api/java/util/EnumMap.html#put%28K,%20V%29
+ *
+ * This property warns if null is about to be inserted as a key.
+ *
+ * @severity error
+ */
+
+EnumMap_NonNull() {
+	event insertnull before(Object e) :
+		call(* EnumMap.put(Object, Object)) && args(e, ..) && condition(e == null) {
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "EnumMap does not permit null.");
+	}
+	event insertnull before(Map m) :
+		call(* EnumMap.putAll(Map)) && args(m) {
+		for (Map.Entry entry : (Set<Map.Entry>)m.entrySet()) {
+			if (entry.getKey() == null) {
+				RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+				RVMLogging.out.println(Level.CRITICAL, "EnumMap does not permit null.");
+			}
+		}
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/EnumSet_NonNull.mop
+++ b/scripts/javamop-agent-bundle/props/EnumSet_NonNull.mop
@@ -1,0 +1,34 @@
+package mop;
+
+import java.util.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if null is added to an EnumSet object.
+ *
+ * EnumSet does not permit null elements.
+ * http://docs.oracle.com/javase/6/docs/api/java/util/EnumSet.html
+ *
+ * This property warns if null is about to be inserted.
+ *
+ * @severity error
+ */
+
+EnumSet_NonNull() {
+	event insertnull before(Object e) :
+		call(* EnumSet+.add(Object)) && args(e) && condition(e == null) {
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "EnumSet does not permit null.");
+	}
+	event insertnull before(Collection c) :
+		call(* EnumSet+.addAll(Collection)) && args(c) {
+		for (Object elem : c) {
+			if (elem == null){
+				RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+				RVMLogging.out.println(Level.CRITICAL, "EnumSet does not permit null.");
+			}
+		}
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/Enum_NoExtraWhiteSpace.mop
+++ b/scripts/javamop-agent-bundle/props/Enum_NoExtraWhiteSpace.mop
@@ -1,0 +1,24 @@
+package mop;
+
+import java.io.*;
+import java.lang.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if the name argument to valueOf() method of Enum contains any whitespace.
+ * 
+ * According to the manual, extraneous whitespace characters are not permitted in the name
+ * for an enum constant.  
+ * http://docs.oracle.com/javase/1.5.0/docs/api/java/lang/Enum.html#valueOf%28java.lang.Class,%20java.lang.String%29
+ * 
+ * @severity error
+ */
+
+Enum_NoExtraWhiteSpace() {
+	event valueOf before(Class c, String name) : call(* Enum+.valueOf(Class, String)) && args(c, name) 
+		&& condition(name.length() != name.trim().length()) {
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "Please use the exact name. No extraneous whitespace characters are permitted");
+	}
+}

--- a/scripts/javamop-agent-bundle/props/File_LengthOnDirectory.mop
+++ b/scripts/javamop-agent-bundle/props/File_LengthOnDirectory.mop
@@ -1,0 +1,24 @@
+package mop;
+
+import java.io.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if length() is invoked on a File object that represents a directory.
+ *
+ * The return value of length() is unspecified if the File instance denotes a
+ * directory.
+ * http://download.oracle.com/javase/6/docs/api/java/io/File.html#length%28%29
+ *
+ * @severity error
+ */
+
+File_LengthOnDirectory() {
+	event bad_length before(File f) :
+		call(* File+.length()) && target(f) && condition(f.isDirectory()) {
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "length() was invoked on a File instance that represents a directory.");
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/HttpCookie_Domain.mop
+++ b/scripts/javamop-agent-bundle/props/HttpCookie_Domain.mop
@@ -1,0 +1,74 @@
+package mop;
+
+import java.net.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if the domain of an HttpCookie object has invalid character.
+ *
+ * The domain name (or pattern), the only parameter of HttpCookie.setDomain(),
+ * should be in the form specified by RFC 2965.
+ * http://docs.oracle.com/javase/6/docs/api/java/net/HttpCookie.html#setDomain%28java.lang.String%29
+ *
+ * According to RFC 2965, the domain value can be either a token or a
+ * quoted-string. A token is defined as follows:
+ *
+ *      token      = 1*<any CHAR except CTLs or separators>
+ *      CHAR       = <any US-ASCII character (octets 0 - 127)>
+ *      CTL        = <any US-ASCII control character
+ *                   (octets 0 - 31) and DEL (127)>
+ *      separators = "(" | ")" | "<" | ">" | "@"
+ *                 | "," | ";" | ":" | "\" | <">
+ *                 | "/" | "[" | "]" | "?" | "="
+ *                 | "{" | "}" | SP | HT
+ *
+ * Since a quoted-string is not defined in RFC 2965, this property assumes a
+ * quoted-string is a sequence of CHARs surrounded by double-quotes.
+ *
+ * @severity error
+ */
+
+HttpCookie_Domain() {
+	event setdomain before(String domain) :
+		call(void HttpCookie.setDomain(String)) && args(domain)
+	{
+		String separators = "()<>@,;:\\\"/[]?={} \t";
+
+		char ch = '0';
+		boolean quoted = false;
+		boolean outofrange = false;
+		boolean hasctrl = false;
+		boolean hassep = false;
+
+		if (domain.length() >= 2 && domain.charAt(0) == '"' && domain.charAt(domain.length() - 1) == '"') {
+			quoted = true;
+			domain = domain.substring(1, domain.length() - 1);
+		}
+
+		for (int i = 0; i < domain.length(); ++i) {
+			ch = domain.charAt(i);
+
+			if (!(0 <= ch && ch <= 127)) {
+				outofrange = true;
+				break;
+			}
+			else if (quoted) {
+				if (ch <= 31 || ch == 127) {
+					hasctrl = true;
+					break;
+				}
+				else if (separators.indexOf(ch) != -1) {
+					hassep = true;
+					break;
+				}
+			}
+		}
+
+		if (outofrange || hasctrl || hassep) {
+			RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+			RVMLogging.out.println(Level.CRITICAL, "The specified domain '" + domain + "' is invalid; it cannot contain '" + ch + "'.");
+		}
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/HttpCookie_Name.mop
+++ b/scripts/javamop-agent-bundle/props/HttpCookie_Name.mop
@@ -1,0 +1,72 @@
+package mop;
+
+import java.net.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if the name of an HttpCookie object has invalid character.
+ *
+ * According to the Java documentation, a HttpCookie name must conform to RFC
+ * 2965.
+ * http://docs.oracle.com/javase/6/docs/api/java/net/HttpCookie.html#HttpCookie%28java.lang.String,%20java.lang.String%29
+ *
+ * There is inconsistency between the Java documentation and RFC 2965,
+ * referred to by the Java documentation. The former states that the name can
+ * contain only ASCII alphanumeric characters and cannot contain commas,
+ * semicolons, or white space or begin with a $ character. The latter sets
+ * slightly different restriction: the name is a token, which is defined as follows
+ * in RFC 2616:
+ *
+ *      token      = 1*<any CHAR except CTLs or separators>
+ *      CHAR       = <any US-ASCII character (octets 0 - 127)>
+ *      CTL        = <any US-ASCII control character
+ *                   (octets 0 - 31) and DEL (127)>
+ *      separators = "(" | ")" | "<" | ">" | "@"
+ *                 | "," | ";" | ":" | "\" | <">
+ *                 | "/" | "[" | "]" | "?" | "="
+ *                 | "{" | "}" | SP | HT
+ *
+ * Since the definition of ASCII alphanumeric character is unclear, this
+ * property is based on RFC 2696; i.e., a name that does not conform to RFC
+ * 2616 will be warned.
+ *
+ * @severity error
+ */
+
+HttpCookie_Name() {
+	event construct before(String name) :
+		call(HttpCookie.new(String, String)) && args(name, ..)
+	{
+		String separators = "()<>@,;:\\\"/[]?={} \t";
+
+		char ch = '0';
+		boolean outofrange = false;
+		boolean hasctrl = false;
+		boolean hassep = false;
+
+		for (int i = 0; i < name.length(); ++i) {
+			ch = name.charAt(i);
+
+			if (!(0 <= ch && ch <= 127)) {
+				outofrange = true;
+				break;
+			}
+			else if (ch <= 31 || ch == 127) {
+				hasctrl = true;
+				break;
+			}
+			else if (separators.indexOf(ch) != -1) {
+				hassep = true;
+				break;
+			}
+		}
+
+		if (outofrange || hasctrl || hassep) {
+			RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+			RVMLogging.out.println(Level.CRITICAL, "The specified cookie name '" + name + "' is invalid; it cannot contain '" + ch + "'.");
+		}
+	}
+}
+
+

--- a/scripts/javamop-agent-bundle/props/HttpURLConnection_SetBeforeConnect.mop
+++ b/scripts/javamop-agent-bundle/props/HttpURLConnection_SetBeforeConnect.mop
@@ -1,0 +1,90 @@
+package mop;
+
+import java.net.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if HttpURLConnection.setFixedLengthStreamingMode(),
+ * setChunkedStreamingMode() or setRequestMethod() is invoked after the
+ * connection was made.
+ *
+ * According to the reference, both setFixedLengthStreamingMode() and
+ * setChunkedStreamingMode() must be called before the URLConnection, which is
+ * a superclass of HttpURLConnection, is connected.
+ * http://docs.oracle.com/javase/6/docs/api/java/net/HttpURLConnection.html#setFixedLengthStreamingMode%28int%29
+ * http://docs.oracle.com/javase/6/docs/api/java/net/HttpURLConnection.html#setChunkedStreamingMode%28int%29
+ *
+ * Although it is not documented, setRequestMethod() must be called before a
+ * connection is made.
+ *
+ * Besides the connect() method, there are many other ways for a URLConnection
+ * object to be connected. It seems that the rule of thumb is any method that
+ * requires server's information, such as response headers and contents,
+ * causes th URLConnection object to be connected. Such methods include, but
+ * not limited to, the following methods:
+ *  URLConnection.connect()
+ *  URLConnection.getContent()
+ *  URLConnection.getContentEncoding()
+ *  URLConnection.getContentLength()
+ *  URLConnection.getContentType()
+ *  URLConnection.getDate()
+ *  URLConnection.getExpiration()
+ *  URLConnection.getHeaderField()
+ *  URLConnection.getHeaderFieldInt()
+ *  URLConnection.getHeaderFields()
+ *  URLConnection.getInputStream()
+ *  URLConnection.getLastModified()
+ *  URLConnection.getOutputStream()
+ *  HttpURLConnection.getErrorStream()
+ *  HttpURLConnection.getHeaderFieldDate()
+ *  HttpURLConnection.getHeaderFieldKey()
+ *  HttpURLConnection.getResponseCode()
+ *  HttpURLConnection.getResponseMessage()
+ *
+ * It should be noted that the above list is not comprehensive since a
+ * subclass may define its own connection-triggering method. For example, the
+ * HttpURLConnection class in the sun.net.www.protocol.http package, a
+ * subclass of java.net.HttpURLConnection, defines one such method,
+ * doTunneling().
+ *
+ * @severity error
+ */
+HttpURLConnection_SetBeforeConnect(HttpURLConnection c) {
+	event set before(HttpURLConnection c) :
+		(
+			call(* HttpURLConnection+.setFixedLengthStreamingMode(..)) ||
+			call(* HttpURLConnection+.setChunkedStreamingMode(..)) ||
+			call(* HttpURLConnection+.setRequestMethod(..))
+		) && target(c) {}
+
+	event connect before(HttpURLConnection c) :
+		(
+			call(* URLConnection+.connect(..)) ||
+			call(* URLConnection+.getContent(..)) ||
+			call(* URLConnection+.getContentEncoding(..)) ||
+			call(* URLConnection+.getContentLength(..)) ||
+			call(* URLConnection+.getContentType(..)) ||
+			call(* URLConnection+.getDate(..)) ||
+			call(* URLConnection+.getExpiration(..)) ||
+			call(* URLConnection+.getHeaderField(..)) ||
+			call(* URLConnection+.getHeaderFieldInt(..)) ||
+			call(* URLConnection+.getHeaderFields(..)) ||
+			call(* URLConnection+.getInputStream(..)) ||
+			call(* URLConnection+.getLastModified(..)) ||
+			call(* URLConnection+.getOutputStream(..)) ||
+			call(* HttpURLConnection+.getErrorStream(..)) ||
+			call(* HttpURLConnection+.getHeaderFieldDate(..)) ||
+			call(* HttpURLConnection+.getHeaderFieldKey(..)) ||
+			call(* HttpURLConnection+.getResponseCode(..)) ||
+			call(* HttpURLConnection+.getResponseMessage(..))
+		) && target(c) {}
+
+	ere : set* connect*
+
+	@fail {
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "setFixedLengthStreamingMode(), setChunkedStreamingMode() or setRequestMethod() should not be invoked after the connection was made.");
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/IDN_ToAscii.mop
+++ b/scripts/javamop-agent-bundle/props/IDN_ToAscii.mop
@@ -1,0 +1,41 @@
+package mop;
+
+import java.net.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if the input to IDN.toASCII() should not be used in an
+ * internationalized domain name.
+ *
+ * IDN.toASCII(), which translates Unicode to ASCII, can fail when the given
+ * string cannot be used in an internationalized domain name.
+ * http://docs.oracle.com/javase/6/docs/api/java/net/IDN.html#toASCII%28java.lang.String%29
+ *
+ * @severity error
+ */
+IDN_ToAscii() {
+	private boolean isAsciiSafe(String input) {
+		for (int i = 0; i < input.length(); ++i) {
+			int c = input.charAt(i);
+			if (c > 0x7f)
+				return false;
+		}
+		return true;
+	}
+
+	event toascii before(String input) :
+		(
+			call(* IDN.toASCII(String)) ||
+			call(* IDN.toASCII(String, int))
+		) && args(input, ..)
+	{
+		boolean safe = this.isAsciiSafe(input);
+
+		if (!safe) {
+			RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+			RVMLogging.out.println(Level.CRITICAL, "The input to IDN.toASCII() should not be used in an internationalized domain name.");
+		}
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/InetAddress_IsReachable.mop
+++ b/scripts/javamop-agent-bundle/props/InetAddress_IsReachable.mop
@@ -1,0 +1,44 @@
+package mop;
+
+import java.net.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if the arguments for an InetAddress.isReachable() call are invalid.
+ *
+ * Both the timeout parameter and the ttl parameter must be 0 or a positive
+ * value.
+ * http://docs.oracle.com/javase/6/docs/api/java/net/InetAddress.html#isReachable%28int%29
+ *
+ * @severity error
+ */
+InetAddress_IsReachable() {
+	event isreachable before(int timeout) :
+		call(* InetAddress+.isReachable(int)) && args(timeout)
+	{
+		if (timeout < 0) {
+			RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+			RVMLogging.out.println(Level.CRITICAL, "The timeout value for InetAddress.isReachable() should not be a negative value.");
+		}
+	}
+
+	event isreachable before(int ttl, int timeout) :
+		call(* InetAddress+.isReachable(NetworkInterface, int, int)) && args(*, ttl, timeout)
+	{
+		if (ttl < 0 || timeout < 0) {
+			RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+
+			if (ttl < 0 && timeout < 0) {
+				RVMLogging.out.println(Level.CRITICAL, "The ttl value and the timeout value for InetAddress.isReachable() should not be negative values.");
+			}
+			else if (ttl < 0) {
+				RVMLogging.out.println(Level.CRITICAL, "The ttl value for InetAddress.isReachable() should not be a negative value.");
+			}
+			else {
+				RVMLogging.out.println(Level.CRITICAL, "The timeout value for InetAddress.isReachable() should not be a negative value.");
+			}
+		}
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/InetSocketAddress_Port.mop
+++ b/scripts/javamop-agent-bundle/props/InetSocketAddress_Port.mop
@@ -1,0 +1,31 @@
+package mop;
+
+import java.net.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if an InetSocketAddress_Port object is created with an invalid port.
+ *
+ * A valid port value is between 0 and 65535 inclusive.
+ * http://docs.oracle.com/javase/6/docs/api/java/net/InetSocketAddress.html#InetSocketAddress%28int%29
+ *
+ * @severity error
+ */
+InetSocketAddress_Port() {
+	event construct before(int port) :
+		(
+			call(InetSocketAddress.new(int)) ||
+			call(InetSocketAddress.new(InetAddress, int)) ||
+			call(InetSocketAddress.new(String, int)) ||
+			call(* InetSocketAddress.createUnresolved(String, int))
+		) && args(.., port)
+	{
+		if (0 <= port && port <= 65535)
+			return;
+
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "The specified port " + port + " is out of range; [0 ~ 65535]");
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/InputStream_ManipulateAfterClose.mop
+++ b/scripts/javamop-agent-bundle/props/InputStream_ManipulateAfterClose.mop
@@ -1,0 +1,42 @@
+package mop;
+
+import java.io.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns read(), available(), reset() or skip() after close().
+ *
+ * According to the BufferedInputStream.close() documentation, read(),
+ * available(), reset() or skip() invocations will throw an IOException, once
+ * the stream has been closed.
+ * http://download.oracle.com/javase/6/docs/api/java/io/BufferedInputStream.html#close%28%29
+ *
+ * Other subclasses of InputStream are deemed to be similar, except
+ * ByteArrayInputStream and StringBufferInputStream.
+ * http://docs.oracle.com/javase/6/docs/api/java/io/ByteArrayInputStream.html#close%28%29
+ *
+ * @severity error
+ */
+
+InputStream_ManipulateAfterClose(InputStream i) {
+	event manipulate before(InputStream i) :
+		(
+			call(* InputStream+.read(..)) ||
+			call(* InputStream+.available(..)) ||
+			call(* InputStream+.reset(..)) ||
+			call(* InputStream+.skip(..))
+		) && target(i) &&
+		!target(ByteArrayInputStream) && !target(StringBufferInputStream) {}
+	creation event close before(InputStream i) :
+		call(* InputStream+.close(..)) && target(i) &&
+		!target(ByteArrayInputStream) && !target(StringBufferInputStream) {}
+
+	ere : close+ manipulate
+
+	@match {
+		RVMLogging.err.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.err.println(Level.CRITICAL, "read(), available(), reset() or skip() was invoked after close().");
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/InputStream_MarkAfterClose.mop
+++ b/scripts/javamop-agent-bundle/props/InputStream_MarkAfterClose.mop
@@ -1,0 +1,26 @@
+package mop;
+
+import java.io.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if mark() is invoked after close().
+ *
+ * According to the InputStream.mark() documentation, mark() after close()
+ * does nothing. This property warns if such useless mark() is invoked.
+ *
+ * @severity warning
+ */
+
+InputStream_MarkAfterClose(InputStream i) {
+	event mark before(InputStream i) : call(* InputStream+.mark(..)) && target(i) {}
+	event close before(InputStream i) : call(* InputStream+.close(..)) && target(i) {}
+
+	ere : close+ mark+
+
+	@match {
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "mark() after close() had no effect.");
+	}
+}

--- a/scripts/javamop-agent-bundle/props/InputStream_MarkReset.mop
+++ b/scripts/javamop-agent-bundle/props/InputStream_MarkReset.mop
@@ -1,0 +1,37 @@
+package mop;
+
+import java.io.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Prevents invocations of mark() if the InputStream does not support.
+ *
+ * Some subclasses of InputStream do not support mark() and reset().
+ * http://download.oracle.com/javase/6/docs/api/java/io/InputStream.html#reset%28%29
+ *
+ * FileInputStream, PushbackInputStream, ObjectInputStream, PipedInputStream
+ * and SequenceInputStream do not support mark() and reset(). This
+ * specification warns if mark() or reset() is invoked. Users tend to assume
+ * that OpenJDK implementation will always raise an exception if a stream does
+ * not support mark(), but this is not guaranteed. In fact,
+ * PushbackInputStream.mark() does nothing.
+ *
+ * @severity error
+ */
+
+InputStream_MarkReset() {
+	event mark_or_reset before() : 
+		(call(* InputStream+.mark(..)) || call(* InputStream+.reset(..)))
+		&& (
+			target(FileInputStream)
+			|| target(PushbackInputStream)
+			|| target(ObjectInputStream)
+			|| target(PipedInputStream)
+			|| target(SequenceInputStream)
+		)
+		{
+			RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+			RVMLogging.out.println(Level.CRITICAL, "FileInputStream, PushbackInputStream, ObjectInputStream, PipedInputStream and SequenceInputStream do not support mark() and reset().");
+		}
+}

--- a/scripts/javamop-agent-bundle/props/InputStream_ReadAheadLimit.mop
+++ b/scripts/javamop-agent-bundle/props/InputStream_ReadAheadLimit.mop
@@ -1,0 +1,98 @@
+package mop;
+
+import java.io.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Raises an error if mark() is invalidated by reading.
+ *
+ * Some subclasses of InputStream support mark() but the mark position can be
+ * invalidated.
+ * http://download.oracle.com/javase/6/docs/api/java/io/InputStream.html#reset%28%29
+ *
+ * BufferedInputStream support mark() and reset(), but after reading the
+ * specified number of bytes, the mark is not preserved and, consequently,
+ * calling reset() is prevented.
+ *
+ * As for DataInputStream and LineNumberInputStream, mark() and reset() rely
+ * on the underlying stream. Therefore, one cannot assume that the mark for
+ * these classes is not invalidated.
+ *
+ * This specification keeps track of validity of the mark, and raises an error
+ * when the mark is invalidated and read() is invoked.
+ *
+ * @severity error
+ */
+
+InputStream_ReadAheadLimit(InputStream i) {
+	int limit = 0;
+	int rest = 0;
+	String LOC = null;
+
+	creation event mark before(InputStream i, int l) : 
+		call(* InputStream+.mark(int)) && target(i) && args(l) && if (
+			i instanceof BufferedInputStream ||
+			i instanceof DataInputStream ||
+			i instanceof LineNumberInputStream
+		) {
+		this.limit = l;
+		this.rest = l;
+	}
+
+	event read1 after(InputStream i) returning(int n) :
+		call(* InputStream+.read()) && target(i) && if (
+			i instanceof BufferedInputStream ||
+			i instanceof DataInputStream ||
+			i instanceof LineNumberInputStream
+		) {
+		if (n != -1) {
+			this.rest -= 1;
+			if (this.rest < 0)
+				this.LOC = __LOC;
+		}
+	}
+
+	event readn after(InputStream i) returning(int n) :
+		call(* InputStream+.read(char[], ..)) && target(i) && if (
+			i instanceof BufferedInputStream ||
+			i instanceof DataInputStream ||
+			i instanceof LineNumberInputStream
+		) {
+		if (n != -1) {
+			this.rest -= n;
+			if (this.rest < 0)
+				this.LOC = __LOC;
+		}
+	}
+
+	event badreset before(InputStream i) : 
+		call(* InputStream+.reset(..)) && target(i) && condition(rest < 0) && if (
+			i instanceof BufferedInputStream ||
+			i instanceof DataInputStream ||
+			i instanceof LineNumberInputStream
+		) {
+		this.limit = 0;
+		this.rest = 0;
+	}
+
+	event goodreset before(InputStream i) : 
+		call(* InputStream+.reset(..)) && target(i) && condition(rest >= 0) && if (
+			i instanceof BufferedInputStream ||
+			i instanceof DataInputStream ||
+			i instanceof LineNumberInputStream
+		) {
+		this.rest = this.limit;
+	}
+
+	ere : (mark | read1 | readn | goodreset)* badreset+
+
+	@match {
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "The position mark has been invalidated.");
+		if (this.LOC != null) {
+			RVMLogging.out.println(Level.CRITICAL, "read() at line " + this.LOC + " invalidated the mark.");
+		}
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/InputStream_UnmarkedReset.mop
+++ b/scripts/javamop-agent-bundle/props/InputStream_UnmarkedReset.mop
@@ -1,0 +1,41 @@
+package mop;
+
+import java.io.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Prevents premature invocations of reset().
+ *
+ * Some subclasses of InputStream allows reset() only after mark() is called.
+ * http://download.oracle.com/javase/6/docs/api/java/io/InputStream.html#reset%28%29
+ *
+ * BufferedInputStream, DataInputStream and LineNumberInputStream allow reset()
+ * only after mark() has been invoked. This specification catches the
+ * violation of this.
+ *
+ * @severity error
+ */
+
+InputStream_UnmarkedReset(InputStream i) {
+	event mark before(InputStream i) : 
+		call(* InputStream+.mark(..)) && target(i) && if (
+			i instanceof BufferedInputStream ||
+			i instanceof DataInputStream ||
+			i instanceof LineNumberInputStream
+		) {}
+
+	event reset before(InputStream i) : 
+		call(* InputStream+.reset(..)) && target(i) && if (
+			i instanceof BufferedInputStream ||
+			i instanceof DataInputStream ||
+			i instanceof LineNumberInputStream
+		) {}
+
+	ere : mark (mark | reset)*
+
+	@fail {
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "BufferedInputStream, DataInputStream and LineNumberInputStream allow reset() only after mark() has been invoked.");
+	}
+}

--- a/scripts/javamop-agent-bundle/props/Integer_BadDecodeArg.mop
+++ b/scripts/javamop-agent-bundle/props/Integer_BadDecodeArg.mop
@@ -1,0 +1,68 @@
+package mop;
+
+import java.io.*;
+import java.lang.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns when the argument to decode is wrong
+ *
+ * According to the manual, the argument cannot contain any whitespace.
+ * Also, there is a format to follow. 
+ * http://docs.oracle.com/javase/6/docs/api/java/lang/Integer.html#decode%28java.lang.String%29
+ *
+ * @severity error
+ */
+Integer_BadDecodeArg() {
+
+    event decode before(Integer i, String nm) : 
+        call(* Integer.decode(String)) && args(nm) && target(i) {
+        if(nm == null || nm.length() == 0){
+            RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+            RVMLogging.out.println(Level.CRITICAL, "Wrong argument to Integer.decode(String nm)");
+        } else {
+            //whitespace check
+            for(int j = 0; j < nm.length(); j++){
+                if(Character.isWhitespace(nm.charAt(j))){
+                    RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+                    RVMLogging.out.println(Level.CRITICAL, "Wrong argument to Integer.decode(String nm)");
+                }
+            }
+            
+            //formatcheck
+            String sub;
+            if(nm.charAt(0) == '-'){
+                sub = nm.substring(1);
+            } else {
+                sub = nm;
+            }
+            
+            int radix = 0;
+            if(sub.startsWith("0x") || sub.startsWith("0X")){
+                sub = sub.substring(2);
+                radix = 16;
+            } else if(sub.startsWith("#")){
+                sub = sub.substring(1);
+                radix = 16;
+            } else if(sub.startsWith("0")){
+                sub = sub.substring(1);
+                radix = 8;
+            } else {
+                radix = 10;
+            }
+            
+            try{
+                if(Integer.parseInt(sub, radix) < 0){
+                    RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+                    RVMLogging.out.println(Level.CRITICAL, "Wrong argument to Integer.decode(String nm)");
+                }
+            } catch(Exception e){
+                RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+                RVMLogging.out.println(Level.CRITICAL, "Wrong argument to Integer.decode(String nm)");
+            }
+            
+        }
+    }
+}
+

--- a/scripts/javamop-agent-bundle/props/InvalidPropertiesFormatException_NonSerializable.mop
+++ b/scripts/javamop-agent-bundle/props/InvalidPropertiesFormatException_NonSerializable.mop
@@ -1,0 +1,43 @@
+package mop;
+
+import java.util.*;
+import java.io.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if an InvalidPropertiesFormatException object is being serialized or
+ * deserialized.
+ *
+ * Although InvalidPropertiesFormatException inherits Serializable the
+ * interface from Exception, it is not intended to be Serializable and
+ * serialization methods are implemented to throw NotSerializableException.
+ * http://docs.oracle.com/javase/6/docs/api/java/util/InvalidPropertiesFormatException.html
+ *
+ * This property warns if an InvalidPropertiesFormatException object is passed
+ * to ObjectOutputStream.writeObject() as an argument. This property misses
+ * errors because writeObject() can be indirectly called inside of JDK. Also,
+ * it cannot detect whether or not ObjectInputStream.readObject() attempted to
+ * deserialize an InvalidPropertiesFormatException object because a correct
+ * implementation of InvalidPropertiesFormatException.readObject() always
+ * throws an exception and there is no way to detect the type that was
+ * attempted.
+ *
+ * @severity error
+ */
+
+InvalidPropertiesFormatException_NonSerializable() {
+	event serialize before(ObjectOutputStream out, InvalidPropertiesFormatException obj) :
+		call(* ObjectOutputStream+.writeObject(..)) &&
+		target(out) && args(obj) {
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "InvalidPropertiesFormatException is not intended to be Serialized.");
+	}
+
+	event deserialize after(ObjectInputStream in) returning(InvalidPropertiesFormatException obj) :
+		call(* ObjectInputStream+.readObject(..)) && target(in) {
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "InvalidPropertiesFormatException is not intended to be Serialized.");
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/Iterator_HasNext.mop
+++ b/scripts/javamop-agent-bundle/props/Iterator_HasNext.mop
@@ -1,0 +1,39 @@
+package mop;
+
+import java.util.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if next() is invoked when hasNext() is not invoked or returns false.
+ *
+ * This property requires that hasNext() be called before next() and that
+ * hasNext() return true. It is a modification of the HasNext property from
+ * tracematches (see ECOOP'07 http://abc.comlab.ox.ac.uk/papers), with the
+ * modification requiring hasNext() to return true.
+ *
+ * This property may raise a false positive because one may safely call next()
+ * multiple times after retrieving the actual number of elements.
+ *
+ * @severity warning
+ */
+
+Iterator_HasNext(Iterator i) {
+	event hasnexttrue after(Iterator i) returning(boolean b) :
+		call(* Iterator+.hasNext())
+		&& target(i) && condition(b) { }
+	event hasnextfalse after(Iterator i) returning(boolean b) :
+		call(* Iterator+.hasNext())
+		&& target(i) && condition(!b) { }
+	event next before(Iterator i) :
+		call(* Iterator+.next())
+		&& target(i) { }
+
+	ltl: [](next => (*) hasnexttrue)
+
+	@violation {
+		RVMLogging.out.println(Level.WARNING, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.WARNING, "Iterator.hasNext() was not called before calling next().");
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/Iterator_RemoveOnce.mop
+++ b/scripts/javamop-agent-bundle/props/Iterator_RemoveOnce.mop
@@ -1,0 +1,34 @@
+package mop;
+
+import java.util.*;
+import java.lang.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if Iterator.remove() is called multiple times per next().
+ *
+ * Iterator.remove() can be called only once per call to next().
+ * http://docs.oracle.com/javase/6/docs/api/java/util/Iterator.html#remove%28%29
+ *
+ * This property warns if remove() is not preceded by next().
+ *
+ * @severity error
+ */
+
+Iterator_RemoveOnce(Iterator i) {
+
+	event remove before(Iterator i) :
+		call(void Iterator+.remove()) && target(i) {}
+
+	event next before(Iterator i) :
+		call(* Iterator+.next()) && target(i) {}
+
+	ere : (next+ (remove | epsilon))*
+
+	@fail {
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "Iterator.remove() can be called only once per call to next().");
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/ListIterator_RemoveOnce.mop
+++ b/scripts/javamop-agent-bundle/props/ListIterator_RemoveOnce.mop
@@ -1,0 +1,37 @@
+package mop;
+
+import java.util.*;
+import java.lang.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if ListIterator.remove() is called multiple times per
+ * next()/previous().
+ *
+ * Iterator.remove() can be called only once per call to next()/previous().
+ * http://docs.oracle.com/javase/6/docs/api/java/util/ListIterator.html#remove%28%29
+ *
+ * This property warns if remove() is not preceded by next() or previous().
+ *
+ * @severity error
+ */
+
+ListIterator_RemoveOnce(ListIterator i) {
+	event remove before(ListIterator i) :
+		call(void Iterator+.remove()) && target(i) {}
+
+	event next before(ListIterator i) :
+		call(* Iterator+.next()) && target(i) {}
+
+	event previous before(ListIterator i) :
+		call(* ListIterator+.previous()) && target(i) {}
+
+	ere : ((next | previous)+ (remove | epsilon))*
+
+	@fail {
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "ListIterator.remove() can be called only once per call to next()/previous().");
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/ListIterator_Set.mop
+++ b/scripts/javamop-agent-bundle/props/ListIterator_Set.mop
@@ -1,0 +1,45 @@
+package mop;
+
+import java.util.*;
+import java.lang.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if ListIterator.set() call is made without next()/previous(), or
+ * after remove()/add().
+ *
+ * ListIterator.set() can be made only if neither remove() nor add() have been
+ * called after the last call to next() or previous().
+ * http://docs.oracle.com/javase/6/docs/api/java/util/ListIterator.html#set%28E%29
+ *
+ * @severity error
+ */
+
+ListIterator_Set(ListIterator i) {
+	creation event create after() returning(ListIterator i) :
+		call(ListIterator Iterable+.listIterator()) {}
+
+	event remove before(ListIterator i) :
+		call(void Iterator+.remove()) && target(i) {}
+
+	event add before(ListIterator i) :
+		call(void ListIterator+.add(..)) && target(i) {}
+
+	event next before(ListIterator i) :
+		call(* Iterator+.next()) && target(i) {}
+
+	event previous before(ListIterator i) :
+		call(* ListIterator+.previous()) && target(i) {}
+
+	event set before(ListIterator i) :
+		call(* ListIterator+.set(..)) && target(i) {}
+
+	ere : create add* ((next | previous)+ set* (remove | add+ | epsilon))*
+
+	@fail {
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "ListIterator.set() can be made only if neither remove() nor add() have been called after the last call to next() or previous().");
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/ListIterator_hasNextPrevious.mop
+++ b/scripts/javamop-agent-bundle/props/ListIterator_hasNextPrevious.mop
@@ -1,0 +1,71 @@
+package mop;
+
+import java.util.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if next()/previous() is invoked when hasNext()/hasPrevious() is not
+ * invoked or returns false.
+ *
+ * This property requires that hasNext()/hasPrevious() be called before
+ * next()/previous() and that hasNext()/hasPrevious() return true.
+ *
+ * @severity warning
+ */
+
+ListIterator_hasNextPrevious(ListIterator i) {
+	event hasnexttrue after(ListIterator i) returning(boolean b) :
+		call(* ListIterator.hasNext()) && target(i) &&
+		condition(b) {}
+	event hasnextfalse after(ListIterator i) returning(boolean b) :
+		call(* ListIterator.hasNext()) && target(i) &&
+		condition(!b) {}
+	event next before(ListIterator i) :
+		call(* ListIterator.next()) && target(i) {}
+
+	event hasprevioustrue after(ListIterator i) returning(boolean b) :
+		call(* ListIterator.hasPrevious()) && target(i) &&
+		condition(b) {}
+	event haspreviousfalse after(ListIterator i) returning(boolean b) :
+		call(* ListIterator.hasPrevious()) && target(i) &&
+		condition(!b) {}
+	event previous before(ListIterator i) :
+		call(* ListIterator.previous()) && target(i) {}
+
+	fsm :
+		na [
+			hasnexttrue -> nextavailable
+			hasnextfalse -> na
+			hasprevioustrue -> prevavailable
+			haspreviousfalse -> na
+		]
+		nextavailable [
+			hasprevioustrue -> bothavailable
+			haspreviousfalse -> nextavailable
+			hasnexttrue -> nextavailable
+			hasnextfalse -> na
+			next -> prevavailable
+		]
+		prevavailable [
+			hasnexttrue -> bothavailable
+			hasnextfalse -> prevavailable
+			hasprevioustrue -> prevavailable
+			haspreviousfalse -> na
+			previous -> nextavailable
+		]
+		bothavailable [
+			hasnexttrue -> bothavailable
+			hasnextfalse -> prevavailable
+			hasprevioustrue -> bothavailable
+			haspreviousfalse -> nextavailable
+			next -> prevavailable
+			previous -> nextavailable
+		]
+
+	@fail {
+		RVMLogging.out.println(Level.WARNING, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.WARNING, "ListIterator.hasNext()/hasPrevious() was not called before calling next()/previous().");
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/List_UnsafeListIterator.mop
+++ b/scripts/javamop-agent-bundle/props/List_UnsafeListIterator.mop
@@ -1,0 +1,57 @@
+package mop;
+
+import java.util.*;
+import java.lang.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if a list is modified while a list iterator is being used.
+ *
+ * If the list is structurally modified at any time after the list iterator is
+ * created, in any way except through the list-iterator's own remove() or
+ * add() methods, the list-iterator will throw
+ * ConcurrentModificationException.
+ * http://docs.oracle.com/javase/6/docs/api/java/util/LinkedList.html#listIterator%28int%29
+ *
+ * This property considers as using an iterator all the ListIterator
+ * operations except add(), remove() and set(). (The first two methods are
+ * allowed according to the documentation, and set() does not structurally
+ * modify the list.)
+ *
+ * Unlike the underlying system, where the fail-fast behavior is not
+ * guaranteed, this property always detects the problematic behavior.
+ *
+ * @severity error
+ */
+
+List_UnsafeListIterator(List l, ListIterator i) {
+	creation event create after(List l) returning(ListIterator i) :
+		call(ListIterator List+.listIterator()) && target(l) {}
+
+	event modify before(List l) :
+		(
+			call(* Collection+.add*(..)) ||
+			call(* Collection+.clear(..)) ||
+			call(* Collection+.remove*(..)) ||
+			call(* Collection+.retain*(..))
+		) && target(l) {}
+
+	event useiter before(ListIterator i) :
+		(
+			call(* Iterator+.hasNext(..)) ||
+			call(* ListIterator+.hasPrevious(..)) ||
+			call(* Iterator+.next(..)) ||
+			call(* ListIterator+.previous(..)) ||
+			call(* ListIterator+.nextIndex(..)) ||
+			call(* ListIterator+.previousIndex(..))
+		) && target(i) {}
+
+	ere : create useiter* modify+ useiter
+
+	@match {
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "The list was modified while a list iterator is being used.");
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/List_UnsynchronizedSubList.mop
+++ b/scripts/javamop-agent-bundle/props/List_UnsynchronizedSubList.mop
@@ -1,0 +1,43 @@
+package mop;
+
+import java.util.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if the list is modified while subList() is running.
+ *
+ * The semantics of the list returned by subList() become undefined if the
+ * backing list (i.e., this list) is structurally modified in any way other
+ * than via the returned list.
+ * http://docs.oracle.com/javase/6/docs/api/java/util/List.html#subList%28int,%20int%29
+ *
+ * This property warns if the backing list is modified while a sub-list,
+ * returned by subList(), is being used.
+ *
+ * @severity error
+ */
+
+List_UnsynchronizedSubList(List b, List s) {
+	creation event createsublist after(List b) returning(List s) :
+		call(* List.subList(..)) && target(b) {}
+
+	event modifybackinglist before(List b) :
+		(
+			call(* Collection+.add*(..)) ||
+			call(* Collection+.remove*(..)) ||
+			call(* Collection+.clear(..)) ||
+			call(* Collection+.retain*(..))
+		) && target(b) {}
+
+	event usesublist before(List s) :
+		call(* List.*(..)) && target(s) {}
+
+	ere : createsublist usesublist* modifybackinglist+ usesublist
+
+	@match {
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "The backing list was modified while a sub-list is being used.");
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/Long_BadDecodeArg.mop
+++ b/scripts/javamop-agent-bundle/props/Long_BadDecodeArg.mop
@@ -1,0 +1,68 @@
+package mop;
+
+import java.io.*;
+import java.lang.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns when the argument to decode is wrong
+ *
+ * According to the manual, the argument cannot contain any whitespace.
+ * Also, there is a format to follow. 
+ * http://docs.oracle.com/javase/6/docs/api/java/lang/Long.html#decode%28java.lang.String%29
+ *
+ * @severity error
+ */
+Long_BadDecodeArg() {
+
+    event decode before(Long l, String nm) : 
+        call(* Long.decode(String)) && args(nm) && target(l) {
+        if(nm == null || nm.length() == 0){
+            RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+            RVMLogging.out.println(Level.CRITICAL, "Wrong argument to Long.decode(String nm)");
+        } else {
+            //whitespace check
+            for(int j = 0; j < nm.length(); j++){
+                if(Character.isWhitespace(nm.charAt(j))){
+                    RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+                    RVMLogging.out.println(Level.CRITICAL, "Wrong argument to Long.decode(String nm)");
+                }
+            }
+            
+            //formatcheck
+            String sub;
+            if(nm.charAt(0) == '-'){
+                sub = nm.substring(1);
+            } else {
+                sub = nm;
+            }
+            
+            int radix = 0;
+            if(sub.startsWith("0x") || sub.startsWith("0X")){
+                sub = sub.substring(2);
+                radix = 16;
+            } else if(sub.startsWith("#")){
+                sub = sub.substring(1);
+                radix = 16;
+            } else if(sub.startsWith("0")){
+                sub = sub.substring(1);
+                radix = 8;
+            } else {
+                radix = 10;
+            }
+            
+            try{
+                if(Long.parseLong(sub, radix) < 0){
+                    RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+                    RVMLogging.out.println(Level.CRITICAL, "Wrong argument to Long.decode(String nm)");
+                }
+            } catch(Exception e){
+                RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+                RVMLogging.out.println(Level.CRITICAL, "Wrong argument to Long.decode(String nm)");
+            }
+            
+        }
+    }
+}
+

--- a/scripts/javamop-agent-bundle/props/Long_BadParsingArgs.mop
+++ b/scripts/javamop-agent-bundle/props/Long_BadParsingArgs.mop
@@ -1,0 +1,64 @@
+package mop;
+
+import java.io.*;
+import java.lang.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns when arguments to parseLong are wrong.
+ *
+ * According to the manual, the first argument cannot be null or of length zero.
+ * Also, radix should be in the range.
+ * http://docs.oracle.com/javase/6/docs/api/java/lang/Long.html#parseLong%28java.lang.String,%20int%29
+ *
+ * @severity warning
+ */
+Long_BadParsingArgs() {
+	event bad_arg before(String s, int radix) : 
+		call(* Long.parseLong(String, int)) && args(s, radix) {
+			if(s == null || s.length() == 0){
+				RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+				RVMLogging.out.println(Level.CRITICAL, "Wrong argument to Long.parseLong(String s, int radix)");
+			} else if(radix < java.lang.Character.MIN_RADIX || radix > java.lang.Character.MAX_RADIX){
+				RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+				RVMLogging.out.println(Level.CRITICAL, "Wrong argument to Long.parseLong(String s, int radix)");
+			} else {
+				for(int j = 0; j < s.length(); j++){
+					if(Character.digit(s.charAt(j), radix) == -1){
+						if(j == 0 && s.length() > 1 && s.charAt(0) == '-'){
+							//okay
+						} else if(j == s.length() - 1 && (s.charAt(j) == 'l' || s.charAt(j) == 'L')){
+							//okay
+						} else {
+							RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+							RVMLogging.out.println(Level.CRITICAL, "Wrong argument to Long.parseLong(String s, int radix)");
+						}
+					} 
+				}
+			}
+		}
+
+	event bad_arg2 before(String s) : 
+		call(* Long.parseLong(String)) && args(s) {
+			if(s == null || s.length() == 0){
+				RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+				RVMLogging.out.println(Level.CRITICAL, "Wrong argument to Long.parseLong(String s)");
+			} else {
+				for(int j = 0; j < s.length(); j++){
+					if(Character.digit(s.charAt(j), 10) == -1){
+						if(j == 0 && s.length() > 1 && s.charAt(0) == '-'){
+							//okay
+						} else if(j == s.length() - 1 && (s.charAt(j) == 'l' || s.charAt(j) == 'L')){
+							//okay
+						} else {
+							RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+							RVMLogging.out.println(Level.CRITICAL, "Wrong argument to Long.parseLong(String s)");
+						}
+					} 
+				}
+			}
+		}
+		
+}
+

--- a/scripts/javamop-agent-bundle/props/Map_CollectionViewAdd.mop
+++ b/scripts/javamop-agent-bundle/props/Map_CollectionViewAdd.mop
@@ -1,0 +1,45 @@
+package mop;
+
+import java.util.*;
+import java.lang.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if a set/collection from a map performs add() or addAll().
+ *
+ * The set/collection, which is returned by Map.keySet(), values() or
+ * entrySet(), supports element removal, but it does not support add() or
+ * addAll() operations.
+ * http://docs.oracle.com/javase/6/docs/api/java/util/Map.html#entrySet%28%29
+ * http://docs.oracle.com/javase/6/docs/api/java/util/Map.html#keySet%28%29
+ * http://docs.oracle.com/javase/6/docs/api/java/util/Map.html#values%28%29
+ *
+ * This property warns if a set/collection view of a map performs add() or
+ * addAll().
+ *
+ * @severity error
+ */
+
+Map_CollectionViewAdd(Map m, Collection c) {
+	creation event getset after(Map m) returning(Collection c) :
+		(
+			call(Set Map+.keySet()) ||
+			call(Set Map+.entrySet()) ||
+			call(Collection Map+.values())
+		) && target(m) {}
+
+	event add before(Collection c) :
+		(
+			call(* Collection+.add(..)) ||
+			call(* Collection+.addAll(..))
+		) && target(c) {}
+
+	ere : getset add+
+
+	@match {
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "A collection/set view of a map does not support add()/addAll().");
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/Map_ItselfAsKey.mop
+++ b/scripts/javamop-agent-bundle/props/Map_ItselfAsKey.mop
@@ -1,0 +1,43 @@
+package mop;
+
+import java.util.*;
+import java.lang.reflect.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if a subclass of Map contains itself as a key.
+ *
+ * The behavior of a map is not specified if the value of an object is changed
+ * in a manner that affects equals() comparisons while the object is a key in
+ * the map. A special case of this prohibition is that it is not permissible
+ * for a map to contain itself as a key.
+ * http://docs.oracle.com/javase/6/docs/api/java/util/Map.html
+ *
+ * This property checks if the special case: a map contains itself by capturing put() and
+ * putAll(). It is hard to detect whether or not equals() comparisons are
+ * affected.
+ *
+ * @severity error
+ */
+
+Map_ItselfAsKey() {
+	event put before(Map map, Object key, Object value) :
+		call(* Map+.put(Object, Object)) && target(map) && args(key, value) {
+		if (key == map) {
+			RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+			RVMLogging.out.println(Level.CRITICAL, "A map cannot contain itself as a key.");
+		}
+	}
+
+	event putall before(Map map, Map src) :
+		call(* Map+.putAll(Map)) && target(map) && args(src) {
+		for (Map.Entry entry : (Set<Map.Entry>)src.entrySet()) {
+			if (entry.getKey() == map) {
+				RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+				RVMLogging.out.println(Level.CRITICAL, "A map cannot contain itself as a key.");
+			}
+		}
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/Map_ItselfAsValue.mop
+++ b/scripts/javamop-agent-bundle/props/Map_ItselfAsValue.mop
@@ -1,0 +1,38 @@
+package mop;
+
+import java.util.*;
+import java.lang.reflect.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if a subclass of Map contains itself as a value.
+ *
+ * While it is permissible for a map to contain itself as a value, extreme
+ * caution is advised: the equals() and hashCode() methods are no longer well
+ * defined on such a map.
+ * http://docs.oracle.com/javase/6/docs/api/java/util/Map.html
+ *
+ * @severity warning
+ */
+
+Map_ItselfAsValue() {
+	event put before(Map map, Object key, Object value) :
+		call(* Map+.put(Object, Object)) && target(map) && args(key, value) {
+		if (value == map) {
+			RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+			RVMLogging.out.println(Level.CRITICAL, "A map cannot contain itself as a value.");
+		}
+	}
+
+	event putall before(Map map, Map src) :
+		call(* Map+.putAll(Map)) && target(map) && args(src) {
+		for (Map.Entry entry : (Set<Map.Entry>)src.entrySet()) {
+			if (entry.getValue() == map) {
+				RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+				RVMLogging.out.println(Level.CRITICAL, "A map cannot contain itself as a value.");
+			}
+		}
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/Map_UnsafeIterator.mop
+++ b/scripts/javamop-agent-bundle/props/Map_UnsafeIterator.mop
@@ -1,0 +1,68 @@
+package mop;
+
+import java.util.*;
+import java.lang.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if a map is modified while an iterator is being used.
+ *
+ * If the map is modified while an iteration over the set/collection is in
+ * progress (except through the iterator's own remove() operation), the
+ * results of the iteration are undefined. The set/collection supports element
+ * removal, which removes the corresponding mapping from the map, via the
+ * Iterator.remove(), Set.remove(), removeAll(), retainAll(), and clear()
+ * operations. However, it does not support the add() or addAll() operations.
+ * http://docs.oracle.com/javase/6/docs/api/java/util/Map.html#entrySet%28%29
+ * http://docs.oracle.com/javase/6/docs/api/java/util/Map.html#keySet%28%29
+ * http://docs.oracle.com/javase/6/docs/api/java/util/Map.html#values%28%29
+ *
+ * This property warns if a map is modified or the returned set performs add()
+ * or addAll() operations while an iterator is being used.
+ *
+ * @severity error
+ */
+
+Map_UnsafeIterator(Map m, Collection c, Iterator i) {
+	creation event getset after(Map m) returning(Collection c) :
+		(
+			call(Set Map+.keySet()) ||
+			call(Set Map+.entrySet()) ||
+			call(Collection Map+.values())
+		) && target(m) {}
+
+	event getiter after(Collection c) returning(Iterator i) :
+		call(Iterator Iterable+.iterator()) && target(c) {}
+
+	event modifyMap before(Map m) :
+		(
+			call(* Map+.clear*(..)) ||
+			call(* Map+.put*(..)) ||
+			call(* Map+.remove(..))
+		) && target(m) {}
+
+	event modifyCol before(Collection c) :
+		(
+			call(* Collection+.clear(..)) ||
+			call(* Collection+.offer*(..)) ||
+			call(* Collection+.pop(..)) ||
+			call(* Collection+.push(..)) ||
+			call(* Collection+.remove*(..)) ||
+			call(* Collection+.retain*(..))
+		) && target(c) {}
+
+	event useiter before(Iterator i) :
+		(
+			call(* Iterator.hasNext(..)) ||
+			call(* Iterator.next(..)) 
+		) && target(i) {}
+
+	ere : getset (modifyMap | modifyCol)* getiter useiter* (modifyMap | modifyCol)+ useiter
+
+	@match {
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "The map was modified while an iteration over the set is in progress.");
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/Map_UnsynchronizedAddAll.mop
+++ b/scripts/javamop-agent-bundle/props/Map_UnsynchronizedAddAll.mop
@@ -1,0 +1,42 @@
+package mop;
+
+import java.util.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if the source map is modified while Map.putAll() is running.
+ *
+ * The behavior of Map.putAll() is undefined if the specified source map is
+ * modified while the operation is in progress.
+ * http://docs.oracle.com/javase/6/docs/api/java/util/Map.html#putAll%28java.util.Map%29
+ *
+ * This property assumes that putAll() of all Map and its subclasses behave
+ * similarly, and warns if put*(), remove*() or clear() is called on the map
+ * that is passed to putAll() as an argument.
+ *
+ * @severity error
+ */
+
+Map_UnsynchronizedAddAll(Map t, Map s) {
+	creation event enter before(Map t, Map s) :
+		call(boolean Map+.putAll(..)) && target(t) && args(s) {}
+
+	event modify before(Map s) :
+		(
+			call(* Map+.clear(..)) ||
+			call(* Map+.put*(..)) ||
+			call(* Map+.remove*(..))
+		) && target(s) {}
+
+	event leave after(Map t, Map s) :
+		call(void Map+.putAll(..)) && target(t) && args(s) {}
+
+	ere : (enter leave modify*)*
+
+	@fail {
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "The source map of putAll() has been modified.");
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/Math_ContendedRandom.mop
+++ b/scripts/javamop-agent-bundle/props/Math_ContendedRandom.mop
@@ -1,0 +1,36 @@
+package mop;
+
+import java.lang.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * suggests if a Math.random() is used by multiple threads.
+ *
+ * According to the manual, Math.random() is thread-safe.  
+ * However, when multiple threads need to generate random numbers,
+ * it may reduce contention for each thread to have its own pseudorandom-number generator.
+ * Random.nextDouble() is recommended in such a case.
+ * http://docs.oracle.com/javase/6/docs/api/java/lang/Math.html#random%28%29
+ * 
+ * @severity suggestion
+ */
+ 
+Math_ContendedRandom() {
+	Thread th = null;
+
+	event onethread_use before(Thread t) :
+		call(* Math.random(..)) && thread(t) && condition(this.th == null || this.th == t){
+			this.th = t;
+		}
+	event otherthread_use before(Thread t) :
+		call(* Math.random(..)) && thread(t) && condition(this.th != null && this.th != t){
+		}
+
+	ere : onethread_use*
+
+	@fail {
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "Math.random() is used by multiple threads. If there is contention, we recommend you to use Random.nextDouble().");
+	}
+}

--- a/scripts/javamop-agent-bundle/props/MulticastSocket_TTL.mop
+++ b/scripts/javamop-agent-bundle/props/MulticastSocket_TTL.mop
@@ -1,0 +1,36 @@
+package mop;
+
+import java.net.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if an invalid TTL value is set for a MulticastSocket object.
+ *
+ * A valid TTL value is between 0 and 255 inclusive.
+ * http://docs.oracle.com/javase/6/docs/api/java/net/InetSocketAddress.html#InetSocketAddress%28int%29
+ *
+ * @severity error
+ */
+MulticastSocket_TTL() {
+	private void check(String msg, int ttl) {
+		if (0 <= ttl && ttl <= 255)
+			return;
+
+		RVMLogging.out.println(Level.CRITICAL, msg);
+		RVMLogging.out.println(Level.CRITICAL, "The specified TTL " + ttl + " is out of range; [0 ~ 255]");
+	}
+
+	event set1 before(byte ttl) :
+		call(* MulticastSocket+.setTTL(byte)) && args(ttl)
+	{
+		this.check(__DEFAULT_MESSAGE, ttl & 0xff);
+	}
+
+	event set2 before(int ttl) :
+		call(* MulticastSocket+.setTimeToLive(int)) && args(ttl)
+	{
+		this.check(__DEFAULT_MESSAGE, ttl);
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/NavigableMap_Modification.mop
+++ b/scripts/javamop-agent-bundle/props/NavigableMap_Modification.mop
@@ -1,0 +1,70 @@
+package mop;
+
+import java.util.*;
+import java.lang.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if there are a NavigableMap object and its descending map, and either
+ * map is modified while an iterator over a collection view of either map is
+ * in progress (except through the iterator's own remove() operation).
+ *
+ * http://docs.oracle.com/javase/6/docs/api/java/util/NavigableMap.html#descendingMap%28%29
+ *
+ * @severity error
+ */
+
+NavigableMap_Modification(NavigableMap m1, NavigableMap m2, Collection c, Iterator i) {
+	creation event create after(NavigableMap m1) returning(NavigableMap m2) :
+		call(NavigableMap NavigableMap+.descendingMap()) && target(m1) {}
+
+	event getset1 after(NavigableMap m1) returning(Collection c) :
+		(
+			call(Set Map+.keySet()) ||
+			call(Set Map+.entrySet()) ||
+			call(Collection Map+.values())
+		) && target(m1) {}
+	event getset2 after(NavigableMap m2) returning(Collection c) :
+		(
+			call(Set Map+.keySet()) ||
+			call(Set Map+.entrySet()) ||
+			call(Collection Map+.values())
+		) && target(m2) {}
+
+	event getiter after(Collection c) returning(Iterator i) :
+		call(Iterator Iterable+.iterator()) && target(c) {}
+
+	event modify1 before(NavigableMap m1) :
+		(
+			call(* Map+.clear*(..)) ||
+			call(* Map+.put*(..)) ||
+			call(* Map+.remove(..))
+		) && target(m1) {}
+	event modify2 before(NavigableMap m2) :
+		(
+			call(* Map+.clear*(..)) ||
+			call(* Map+.put*(..)) ||
+			call(* Map+.remove(..))
+		) && target(m2) {}
+
+	event modify3 before(Collection c) :
+		(
+			call(* Collection+.add(..)) ||
+			call(* Collection+.addAll(..))
+		) && target(c) {}
+
+	event useiter before(Iterator i) :
+		(
+			call(* Iterator.hasNext(..)) ||
+			call(* Iterator.next(..)) 
+		) && target(i) {}
+
+	ere : create (modify1 | modify2)* (getset1 | getset2) (modify1 | modify2 | modify3)* getiter useiter* (modify1 | modify2 | modify3)+ useiter
+
+	@match {
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "The NavigableMap was modified while an iteration over a collection view of a NavigableMap that shares the same storage.");
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/NavigableMap_UnsafeIterator.mop
+++ b/scripts/javamop-agent-bundle/props/NavigableMap_UnsafeIterator.mop
@@ -1,0 +1,61 @@
+package mop;
+
+import java.util.*;
+import java.lang.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if a NavigableMap is modified while an iterator is being used.
+ *
+ * If the map is modified while an iteration over the set/collection is in
+ * progress (except through the iterator's own remove() operation), the
+ * results of the iteration are undefined. The set/collection supports element
+ * removal, which removes the corresponding mapping from the map, via the
+ * Iterator.remove(), Set.remove(), removeAll(), retainAll(), and clear()
+ * operations. However, it does not support the add() or addAll() operations.
+ * http://docs.oracle.com/javase/6/docs/api/java/util/NavigableMap.html#navigableKeySet%28%29
+ *
+ * This property warns if a map is modified or the returned set performs add()
+ * or addAll() operations while an iterator is being used.
+ *
+ * @severity error
+ */
+
+NavigableMap_UnsafeIterator(NavigableMap m, Set s, Iterator i) {
+	creation event getset after(NavigableMap m) returning(Set s) :
+		(
+			call(Set NavigableMap+.navigableKeySet()) ||
+			call(Set NavigableMap+.descendingKeySet())
+		) && target(m) {}
+
+	event getiter after(Set s) returning(Iterator i) :
+		call(Iterator Iterable+.iterator()) && target(s) {}
+
+	event modifyMap before(NavigableMap m) :
+		(
+			call(* Map+.clear*(..)) ||
+			call(* Map+.put*(..)) ||
+			call(* Map+.remove*(..))
+		) && target(m) {}
+
+	event modifySet before(Set s) :
+		(
+			call(* Collection+.add(..)) ||
+			call(* Collection+.addAll(..))
+		) && target(s) {}
+
+	event useiter before(Iterator i) :
+		(
+			call(* Iterator.hasNext(..)) ||
+			call(* Iterator.next(..)) 
+		) && target(i) {}
+
+	ere : getset (modifyMap | modifySet)* getiter useiter* (modifyMap | modifySet)+ useiter
+
+	@match {
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "The NavigableMap was modified while an iteration over the set is in progress.");
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/NavigableSet_Modification.mop
+++ b/scripts/javamop-agent-bundle/props/NavigableSet_Modification.mop
@@ -1,0 +1,57 @@
+package mop;
+
+import java.util.*;
+import java.lang.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if there are a NavigableSet object and its descending set, and either
+ * set is modified while an iterator over either set is in progress (except
+ * through the iterator's own remove() operation).
+ *
+ * http://docs.oracle.com/javase/6/docs/api/java/util/NavigableSet.html#descendingSet%28%29
+ *
+ * @severity error
+ */
+
+NavigableSet_Modification(NavigableSet s1, NavigableSet s2, Iterator i) {
+	creation event create after(NavigableSet s1) returning(NavigableSet s2) :
+		call(NavigableSet NavigableSet+.descendingSet()) && target(s1) {}
+
+	event getiter1 after(NavigableSet s1) returning(Iterator i) :
+		call(Iterator Iterable+.iterator()) && target(s1) {}
+
+	event getiter2 after(NavigableSet s2) returning(Iterator i) :
+		call(Iterator Iterable+.iterator()) && target(s2) {}
+
+	event modify1 before(NavigableSet s1) :
+		(
+			call(* Collection+.add*(..)) ||
+			call(* Collection+.clear(..)) ||
+			call(* Collection+.remove*(..)) ||
+			call(* Collection+.retain*(..))
+		) && target(s1) {}
+		
+	event modify2 before(NavigableSet s2) :
+		(
+			call(* Collection+.add*(..)) ||
+			call(* Collection+.clear(..)) ||
+			call(* Collection+.remove*(..)) ||
+			call(* Collection+.retain*(..))
+		) && target(s2) {}
+
+	event useiter before(Iterator i) :
+		(
+			call(* Iterator.hasNext(..)) ||
+			call(* Iterator.next(..)) 
+		) && target(i) {}
+
+	ere : create (modify1 | modify2)* (getiter1 | getiter2) useiter* (modify1 | modify2)+ useiter
+
+	@match {
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "The NavigableSet was modified while an iteration over a NavigableSet that shares the same storage.");
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/NetPermission_Actions.mop
+++ b/scripts/javamop-agent-bundle/props/NetPermission_Actions.mop
@@ -1,0 +1,26 @@
+package mop;
+
+import java.net.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if the "actions' value for NetPermission is not null.
+ *
+ * The "actions" value, a parameter of a NetPermission constructor, is unused,
+ * as of Java 6, and should be null.
+ * http://docs.oracle.com/javase/6/docs/api/java/net/NetPermission.html#NetPermission%28java.lang.String,%20java.lang.String%29
+ *
+ * @severity error
+ */
+NetPermission_Actions() {
+	event construct before(String actions) :
+		call(NetPermission.new(String, String)) && args(.., actions)
+	{
+		if (actions != null) {
+			RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+			RVMLogging.out.println(Level.CRITICAL, "The 'actions' value should be null.");
+		}
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/NetPermission_Name.mop
+++ b/scripts/javamop-agent-bundle/props/NetPermission_Name.mop
@@ -1,0 +1,40 @@
+package mop;
+
+import java.net.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if a target name for NetPermission does not conform to the naming
+ * convention.
+ *
+ * The naming convention follows the hierarchical property naming convention.
+ * Also, an asterisk may appear at the end of the name, following a ".", or by
+ * itself, to signify a wildcard match.
+ * http://docs.oracle.com/javase/6/docs/api/java/net/NetPermission.html#NetPermission%28java.lang.String%29
+ *
+ * @severity error
+ */
+NetPermission_Name() {
+	event construct before(String name) :
+		(
+			call(NetPermission.new(String)) ||
+			call(NetPermission.new(String, String))
+		) && args(name, ..)
+	{
+		boolean valid = true;
+		for (int i = 0; i < name.length() - 1; ++i) {
+			char c = name.charAt(i);
+			if (c == '*') {
+				valid = false;
+				break;
+			}
+		}
+
+		if (!valid) {
+			RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+			RVMLogging.out.println(Level.CRITICAL, "The target name " + name + " does not conform to the naming convention.");
+		}
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/ObjectStreamClass_Initialize.mop
+++ b/scripts/javamop-agent-bundle/props/ObjectStreamClass_Initialize.mop
@@ -1,0 +1,34 @@
+package mop;
+
+import java.io.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns write operation after close().
+ *
+ * According to the FileOutputStream.close(), a file output stream may no
+ * longer be used for writing bytes, once the stream has been closed.
+ *
+ * @severity error
+ */
+
+ObjectStreamClass_Initialize(ObjectStreamClass c) {
+	event create after() returning(ObjectStreamClass c) :
+		call(ObjectStreamClass+.new()) {}
+	event init before(ObjectStreamClass c) :
+		(
+			call(* ObjectStreamClass+.initProxy(..)) ||
+			call(* ObjectStreamClass+.initNonProxy(..)) ||
+			call(* ObjectStreamClass+.readNonProxy(..))
+		) && target(c) {}
+	event endProg before() : endProgram() {}
+
+	ltl : [](create => o init)
+
+	@violation {
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "An ObjectStreamClass object was instantiated, but was not initialized using initProxy(), initNonProxy() or readNonProxy()");
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/Object_MonitorOwner.mop
+++ b/scripts/javamop-agent-bundle/props/Object_MonitorOwner.mop
@@ -1,0 +1,36 @@
+package mop;
+
+import java.io.*;
+import java.lang.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if notify(), notifyAll(), and wait(..) methods are called without holding the monitor of the object.
+ *
+ * According to the manual, those methods can only be called by a thread that is the owner of the object's monitor.
+ * http://docs.oracle.com/javase/6/docs/api/java/lang/Object.html#notify%28%29
+ * http://docs.oracle.com/javase/6/docs/api/java/lang/Object.html#notifyAll%28%29
+ * http://docs.oracle.com/javase/6/docs/api/java/lang/Object.html#wait%28%29
+ * http://docs.oracle.com/javase/6/docs/api/java/lang/Object.html#wait%28long%29
+ * http://docs.oracle.com/javase/6/docs/api/java/lang/Object.html#wait%28long,%20int%29
+ *
+ * @severity error
+ */
+ 
+Object_MonitorOwner() {
+	event bad_notify before(Object o): 
+		(call(* Object+.notify(..)) || call(* Object+.notifyAll(..)))&& target(o) && if(!Thread.holdsLock(o)) {
+			RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+			RVMLogging.out.println(Level.CRITICAL, "notify() and notifyAll() can be called only by the owner of this object's monitor.");
+		}
+        
+	event bad_wait before(Object o): 
+		call(* Object+.wait(..)) && target(o) && if(!Thread.holdsLock(o)) {
+			RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+			RVMLogging.out.println(Level.CRITICAL, "wait() can be called only by the owner of this object's monitor.");
+		}
+        
+    
+}
+

--- a/scripts/javamop-agent-bundle/props/Object_NoClone.mop
+++ b/scripts/javamop-agent-bundle/props/Object_NoClone.mop
@@ -1,0 +1,33 @@
+package mop;
+
+import java.io.*;
+import java.lang.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if clone method is called on an Object instance.
+ *
+ * According to the manual, Object class itself does not implement Cloneable.
+ * Calling clone() will cause an exception on runtime.  
+ * http://docs.oracle.com/javase/6/docs/api/java/lang/Object.html#clone%28%29
+ *
+ * @severity error
+ */
+ 
+Object_NoClone() {
+	event clone before(Object o):
+		call(* Object.clone())
+		&& !within(org.apache.xerces.dom.NodeImpl)
+		&& !within(org.apache.batik.bridge.UpdateManager)
+		&& !within(org.codehaus.janino.ScriptEvaluator)
+		&& !within(org.apache.batik.ext.awt.image.codec.png.PNGEncodeParam)
+		&& !within(org.apache.batik.ext.awt.image.spi.MagicNumberRegistryEntry)
+		&& !within(org.apache.xerces.util.XMLCatalogResolver)
+		&& target(o) && condition(o.getClass().getCanonicalName().equals("java.lang.Object")){
+			RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+			RVMLogging.out.println(Level.CRITICAL, "Using the clone method on an Object instance will result in throwing an exception.");
+	}
+
+}
+

--- a/scripts/javamop-agent-bundle/props/OutputStream_ManipulateAfterClose.mop
+++ b/scripts/javamop-agent-bundle/props/OutputStream_ManipulateAfterClose.mop
@@ -1,0 +1,39 @@
+package mop;
+
+import java.io.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns write() or flush() after close().
+ *
+ * According to the OutputStream.close(), a closed stream cannot perform
+ * output operations and cannot be reopened in general.
+ * http://download.oracle.com/javase/6/docs/api/java/io/OutputStream.html#close%28%29
+ *
+ * ByteArrayOutputStream is an exceptional subclass in that methods in this
+ * class can be called after the stream has been closed.
+ * http://docs.oracle.com/javase/6/docs/api/java/io/ByteArrayOutputStream.html#close%28%29
+ *
+ * @severity error
+ */
+
+OutputStream_ManipulateAfterClose(OutputStream o) {
+	event manipulate before(OutputStream o) :
+		(
+			call(* OutputStream+.write*(..)) ||
+			call(* OutputStream+.flush(..))
+		) && target(o) &&
+		!target(ByteArrayOutputStream) {}
+	creation event close before(OutputStream o) :
+		call(* OutputStream+.close(..)) && target(o) && 
+		!target(ByteArrayOutputStream) {}
+
+	ere : close+ manipulate+
+
+	@match {
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "write() or flush() was invoked after close()."); 
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/PasswordAuthentication_FillZeroPassword.mop
+++ b/scripts/javamop-agent-bundle/props/PasswordAuthentication_FillZeroPassword.mop
@@ -1,0 +1,36 @@
+package mop;
+
+import java.net.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if the password obtained from PasswordAuthentication.getPassword() is
+ * not zeroed out.
+ *
+ * It is caller's responsibility to zero out the password information,
+ * obtained from PasswordAuthentication.getPassword(), after it is no longer
+ * needed.
+ * http://docs.oracle.com/javase/6/docs/api/java/net/PasswordAuthentication.html#getPassword%28%29
+ *
+ * This specification warns if the password is obtained but never zeroed out
+ * using Arrays.fill(). It may raise false alarms if a client zeroes the
+ * password buffer using other methods.
+ *
+ * @severity warning
+ */
+PasswordAuthentication_FillZeroPassword(Object pwd) {
+	event read after() returning(Object pwd) :
+		call(char[] PasswordAuthentication+.getPassword(..)) {}
+	event obliterate before(Object pwd) :
+		call(* Arrays.fill(char[], char)) && args(pwd, ..) {}
+	event endProg before() : endProgram() {}
+	
+	ltl : [](read => o obliterate)
+
+	@violation {
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "The password, obtained from PasswordAuthentication.getPassword(), has never been obliterated.");
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/PipedInputStream_UnconnectedRead.mop
+++ b/scripts/javamop-agent-bundle/props/PipedInputStream_UnconnectedRead.mop
@@ -1,0 +1,55 @@
+package mop;
+
+import java.io.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if an unconnected PipedInputStream object performs a read operation.
+ *
+ * If the pipe is broken, read() fails and a runtime exception is raised.
+ * http://download.oracle.com/javase/6/docs/api/java/io/PipedInputStream.html#read%28%29
+ *
+ * @severity error
+ */
+PipedInputStream_UnconnectedRead(PipedInputStream i) {
+	creation event create after() returning(PipedInputStream i) :
+		call(PipedInputStream+.new()) {}
+	creation event create_oi after() returning(PipedInputStream i) :
+		call(PipedInputStream+.new(PipedOutputStream+)) {}
+
+	event create_io before(PipedInputStream i) :
+		call(PipedOutputStream+.new(PipedInputStream+)) && args(i) {}
+
+	event connect1 before(PipedInputStream i) :
+		call(* PipedOutputStream+.connect(PipedInputStream+)) && args(i) {}
+	event connect2 before(PipedInputStream i) :
+		call(* PipedInputStream+.connect(PipedOutputStream+)) && target(i) {}
+
+	event read before(PipedInputStream i) :
+		(
+			call(* PipedInputStream+.read(..)) ||
+			call(* PipedInputStream+.receive(..)) ||
+			call(* PipedInputStream+.available(..))
+		) && target(i) {}
+
+	fsm :
+		initial [
+			create -> unconnected
+			create_oi -> connected
+		]
+		unconnected [
+			create_io -> connected
+			connect1 -> connected
+			connect2 -> connected
+		]
+		connected [
+			read -> connected
+		]
+
+	@fail {
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "An unconnected PipedInputStream performed read() operation.");
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/PipedOutputStream_UnconnectedWrite.mop
+++ b/scripts/javamop-agent-bundle/props/PipedOutputStream_UnconnectedWrite.mop
@@ -1,0 +1,51 @@
+package mop;
+
+import java.io.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if an unconnected PipedOutputStream object performs a write operation.
+ *
+ * If the pipe is broken, write() fails and a runtime exception is raised.
+ * http://download.oracle.com/javase/6/docs/api/java/io/PipedOutputStream.html#write%28int%29
+ *
+ * @severity error
+ */
+PipedOutputStream_UnconnectedWrite(PipedOutputStream o) {
+	creation event create after() returning(PipedOutputStream o) :
+		call(PipedOutputStream+.new()) {}
+	creation event create_io after() returning(PipedOutputStream o) :
+		call(PipedOutputStream+.new(PipedInputStream+)) {}
+
+	event create_oi before(PipedOutputStream o) :
+		call(PipedInputStream+.new(PipedOutputStream+)) && args(o) {}
+
+	event connect1 before(PipedOutputStream o) :
+		call(* PipedInputStream+.connect(PipedOutputStream+)) && args(o) {}
+	event connect2 before(PipedOutputStream o) :
+		call(* PipedOutputStream+.connect(PipedInputStream+)) && target(o) {}
+
+	event write before(PipedOutputStream o) :
+		call(* PipedOutputStream+.write(..)) && target(o) {}
+
+	fsm :
+		initial [
+			create -> unconnected
+			create_io -> connected
+		]
+		unconnected [
+			create_oi -> connected
+			connect1 -> connected
+			connect2 -> connected
+		]
+		connected [
+			write -> connected
+		]
+
+	@fail {
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "An unconnected PipedOutputStream performed write() operation.");
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/PipedStream_SingleThread.mop
+++ b/scripts/javamop-agent-bundle/props/PipedStream_SingleThread.mop
@@ -1,0 +1,46 @@
+package mop;
+
+import java.io.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if a single thread attempts to use both a PipedInputStream instance
+ * and a PipedOutputStream instance.
+ *
+ * As Java compilers and runtime do not detect the violation of this property
+ * and violating it may lead to deadlock, it is encouraged to enable this
+ * property.
+ *
+ * According to the manual, attempting to use both objects from a single
+ * thread is not recommended, as it may deadlock the thread.
+ * http://download.oracle.com/javase/6/docs/api/java/io/PipedInputStream.html
+ *
+ * This property warns if that attempt is detected.
+ *
+ * @severity warning
+ */
+PipedStream_SingleThread(PipedInputStream i, PipedOutputStream o, Thread t) {
+	creation event create1 after(PipedOutputStream o) returning(PipedInputStream i) :
+		call(PipedInputStream+.new(PipedOutputStream+)) && args(o) {}
+	creation event create2 before(PipedInputStream i, PipedOutputStream o) :
+		call(* PipedInputStream+.connect(PipedOutputStream+)) && target(i) && args(o) {}
+	creation event create3 after(PipedInputStream i) returning(PipedOutputStream o) :
+		call(PipedOutputStream+.new(PipedInputStream+)) && args(i) {}
+	creation event create4 before(PipedOutputStream o, PipedInputStream i) :
+		call(* PipedOutputStream+.connect(PipedInputStream+)) && target(o) && args(i) {}
+
+	event write before(PipedOutputStream o, Thread t) :
+		call(* OutputStream+.write(..)) && target(o) && thread(t) {}
+
+	event read before(PipedInputStream i, Thread t) :
+		call(* InputStream+.read(..)) && target(i) && thread(t) {}
+
+	ere: (create1 | create2 | create3 | create4) (write* | read*)
+
+	@fail {
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "A single thread attempted to use both a PipedInputStream instance and a PipedOutputStream instance, which may deadlock the thread.");
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/PriorityQueue_NonComparable.mop
+++ b/scripts/javamop-agent-bundle/props/PriorityQueue_NonComparable.mop
@@ -1,0 +1,44 @@
+package mop;
+
+import java.util.*;
+import java.lang.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if PriorityQueue is about to have a non-comparable object.
+ *
+ * PriorityQueue does not permit non-comparable elements.
+ * http://docs.oracle.com/javase/6/docs/api/java/util/PriorityQueue.html
+ *
+ * The definition of a non-comparable object is not clear, but it is assumed
+ * that an object that does not implement the Comparable interface is deemed
+ * to be non-comparable.
+ *
+ * @severity error
+ */
+
+PriorityQueue_NonComparable() {
+	event insertnull before(Object e) :
+		(
+			call(* Collection+.add*(..)) ||
+			call(* Queue+.offer*(..))
+		) && target(PriorityQueue) && args(e) {
+		if (!(e instanceof Comparable)) {
+			RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+			RVMLogging.out.println(Level.CRITICAL, "PriorityQueue does not permit non-comparable objects.");
+		}
+	}
+
+	event insertnull before(Collection c) :
+		call(* Collection+.addAll(Collection)) &&
+		target(PriorityQueue) && args(c) {
+		for (Object elem : c) {
+			if (!(elem instanceof Comparable)) {
+				RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+				RVMLogging.out.println(Level.CRITICAL, "PriorityQueue does not permit non-comparable objects.");
+			}
+		}
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/PriorityQueue_NonNull.mop
+++ b/scripts/javamop-agent-bundle/props/PriorityQueue_NonNull.mop
@@ -1,0 +1,40 @@
+package mop;
+
+import java.util.*;
+import java.lang.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if PriorityQueue is about to have a null element.
+ *
+ * PriorityQueue does not permit null elements.
+ * http://docs.oracle.com/javase/6/docs/api/java/util/PriorityQueue.html
+ *
+ * This property warns if null is about to be inserted.
+ *
+ * @severity error
+ */
+
+PriorityQueue_NonNull() {
+	event insertnull before(Object e) :
+		(
+			call(* Collection+.add*(..)) ||
+			call(* Queue+.offer*(..))
+		) && target(PriorityQueue) && args(e) && condition(e == null) {
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "PriorityQueue does not permit null.");
+	}
+
+	event insertnull before(Collection c) :
+		call(* Collection+.addAll(Collection)) &&
+		target(PriorityQueue) && args(c) {
+		for (Object elem : c) {
+			if (elem == null) {
+				RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+				RVMLogging.out.println(Level.CRITICAL, "PriorityQueue does not permit null.");
+			}
+		}
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/ProcessBuilder_NullKeyOrValue.mop
+++ b/scripts/javamop-agent-bundle/props/ProcessBuilder_NullKeyOrValue.mop
@@ -1,0 +1,45 @@
+package mop;
+
+import java.io.*;
+import java.lang.*;
+import java.util.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if null key or value is inserted.
+ *
+ * According to the manual, the returned map from environment() does not permit null keys or values.  
+ * http://docs.oracle.com/javase/6/docs/api/java/lang/ProcessBuilder.html
+ * Attempting to insert or query the presence of a null key or value will throw an exception.
+ *
+ * @severity error
+ */
+
+ProcessBuilder_NullKeyOrValue(Map map){
+	creation event createMap after() returning(Map map) : 
+        call(* ProcessBuilder.environment()) {}
+              
+	event nullPut before(Map map, Object key, Object value) : 
+        call(* Map.put(..)) && args(key, value) && target(map) && condition(key == null || value == null){}
+
+	event nullPut before(Map map, Map map2) : 
+        call(* Map.putAll(Map)) && args(map2) && target(map) && condition(map2.containsKey(null) || map2.containsValue(null)){}
+
+	event nullQuery before(Map map, Object o) : 
+	    (call(* Map.containsKey(..)) || call(* Map.containsValue(..)) || call(* Map.get(..)) || call(* Map.remove(..))) && target(map) && args(o) && condition(o == null){}
+
+    ere : createMap (nullPut | nullQuery)+ 
+
+	@match{
+           RVMLogging.out.println(Level.WARNING, __DEFAULT_MESSAGE);
+           RVMLogging.out.println(Level.WARNING, "null key or value is not permitted in the map from ProcessBuilder.environment()");
+	}
+}
+		
+
+
+
+
+
+

--- a/scripts/javamop-agent-bundle/props/ProcessBuilder_ThreadSafe.mop
+++ b/scripts/javamop-agent-bundle/props/ProcessBuilder_ThreadSafe.mop
@@ -1,0 +1,46 @@
+package mop;
+
+import java.io.*;
+import java.lang.*;
+import java.util.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if two threads attempt to use the same ProcessBuilder object.
+ *
+ * According to the manual, this class is not synchronized.
+ * http://docs.oracle.com/javase/6/docs/api/java/lang/ProcessBuilder.html
+ * User should use external synchronization.
+ *
+ * @severity warning
+ */
+
+ProcessBuilder_ThreadSafe(ProcessBuilder p){
+    Thread owner = null;
+
+    event safe_oper before(ProcessBuilder p, Thread t) : 
+        call(* ProcessBuilder.*(..)) && target(p) && thread(t)
+        && condition(this.owner == null || this.owner == t) {
+            this.owner = t;
+        }
+    
+    event unsafe_oper before(ProcessBuilder p, Thread t) : 
+        call(* ProcessBuilder.*(..)) && target(p) && thread(t)
+        && condition(this.owner != null && this.owner != t) {}
+
+	ere: safe_oper*
+
+	@fail {
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "More than two threads attempted to use a ProcessBuilder instance, which may lead to a race condition");
+		__RESET;
+	}
+}
+		
+
+
+
+
+
+

--- a/scripts/javamop-agent-bundle/props/Properties_ManipulateAfterLoad.mop
+++ b/scripts/javamop-agent-bundle/props/Properties_ManipulateAfterLoad.mop
@@ -1,0 +1,45 @@
+package mop;
+
+import java.util.*;
+import java.io.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns read(), available(), reset() or skip() after close().
+ *
+ * Properties.loadFromXML() takes an InputStream object, uses it, and then
+ * closes it when it returns. That is, calling loadFromXML() is like calling
+ * InputStream.close(), and the InputStream object should be considered
+ * closed.
+ * http://docs.oracle.com/javase/6/docs/api/java/util/Properties.html#loadFromXML%28java.io.InputStream%29
+ *
+ * This property is similar to InputStream_ManipulateAfterClose; only 'close'
+ * event is different.
+ *
+ * @severity error
+ */
+
+Properties_ManipulateAfterLoad(InputStream i) {
+	event manipulate before(InputStream i) :
+		(
+			call(* InputStream+.read(..)) ||
+			call(* InputStream+.available(..)) ||
+			call(* InputStream+.reset(..)) ||
+			call(* InputStream+.skip(..))
+		) && target(i) &&
+		!target(ByteArrayInputStream) && !target(StringBufferInputStream) {}
+
+	creation event close after(InputStream i) :
+		call(* Properties+.loadFromXML(InputStream)) && args(i) &&
+		!args(ByteArrayInputStream) && !args(StringBufferInputStream) {}
+
+	ere : close+ manipulate
+
+	@match {
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "read(), available(), reset() or skip() was invoked after Properties.loadFromXML() closes the stream.");
+	}
+}
+
+

--- a/scripts/javamop-agent-bundle/props/PushbackInputStream_UnreadAheadLimit.mop
+++ b/scripts/javamop-agent-bundle/props/PushbackInputStream_UnreadAheadLimit.mop
@@ -1,0 +1,116 @@
+package mop;
+
+import java.io.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if unread() is invoked when the internal pushback buffer is full.
+ *
+ * A PushbackInputStream is capable of pushing back multiple bytes to the front of
+ * the stream. Typically, it is used for reading indefinite number of bytes until
+ * a delimiter is detected, and pushing back that delimiter so that the very next
+ * read() operation can see the delimiter again.
+ * http://download.oracle.com/javase/6/docs/api/java/io/PushbackInputStream.html
+ *
+ * Since the internal pushback buffer has limited capacity, performing
+ * unread() beyond its capacity causes a runtime error.
+ * http://download.oracle.com/javase/6/docs/api/java/io/PushbackInputStream.html#unread%28byte[]%29
+ *
+ * This property records the capacity of the pushback buffer, keeps track of
+ * read() and unread() operations, and warns if the buffer is full but
+ * unread() is invoked.
+ *
+ * @severity error
+ */
+
+PushbackInputStream_UnreadAheadLimit(PushbackInputStream p) {
+	int limit;
+	int pos;
+
+	creation event create after() returning(PushbackInputStream p) :
+		call(PushbackInputStream+.new(InputStream)) {
+		this.limit = 1;
+		this.pos = 1;
+	}
+	creation event create after(int size) returning(PushbackInputStream p) :
+		call(PushbackInputStream+.new(InputStream, int)) && args(.., size) {
+		this.limit = size;
+		this.pos = size;
+	}
+
+	event read1 after(PushbackInputStream p) returning(int r) :
+		call(* PushbackInputStream+.read()) && target(p) {
+		if (this.pos < this.limit)
+			this.pos++;
+	}
+	event read2 after(PushbackInputStream p) returning(int n) :
+		call(* PushbackInputStream+.read(byte[], int, int)) && target(p) {
+		int avail = this.limit - this.pos;
+		if (avail > 0) {
+			if (n < avail)
+				avail = n;
+			this.pos += avail;
+		}
+	}
+
+	/* XXX The order of event definitions matters here!
+	 * Although pos > 0 and pos == 0 can never be satisfied at the same time,
+	 * one of them is executed first and then the condition is re-evaluated;
+	 * i.e., the modification made by the first event handler affects the
+	 * condition of the second event.
+	 */
+	event safeunread before(PushbackInputStream p) :
+		call(* PushbackInputStream+.unread(int)) && target(p) &&
+		condition(pos > 0) {
+		--this.pos;
+	}
+	event unsafeunread before(PushbackInputStream p) :
+		call(* PushbackInputStream+.unread(int)) && target(p) &&
+		condition(pos == 0) {
+	}
+
+	/* XXX byte[] causes a parsing error. One can rewrite byte[] with Object,
+	 * but it's tedious and looks ugly.
+	 */
+/*
+	event safeunread before(PushbackInputStream p, byte[] b) :
+		call(* PushbackInputStream+.unread(byte[])) && target(p) && args(b) &&
+		condition(pos >= b.length) {
+		this.pos -= b.length;
+	}
+	event unsafeunread before(PushbackInputStream p, byte[] b) :
+		call(* PushbackInputStream+.unread(byte[])) && target(p) && args(b) &&
+		condition(pos < b.length) {
+	}
+*/
+	event safeunread before(PushbackInputStream p, Object b) :
+		call(* PushbackInputStream+.unread(byte[])) && target(p) && args(b) &&
+		condition(pos >= ((byte[])b).length) {
+		this.pos -= ((byte[])b).length;
+	}
+	event unsafeunread before(PushbackInputStream p, Object b) :
+		call(* PushbackInputStream+.unread(byte[])) && target(p) && args(b) &&
+		condition(pos < ((byte[])b).length) {
+	}
+
+	event safeunread before(PushbackInputStream p, int len) :
+		call(* PushbackInputStream+.unread(byte[], int, int)) && target(p) &&
+		args(.., len) &&
+		condition(pos >= len) {
+		this.pos -= len;
+	}
+	event unsafeunread before(PushbackInputStream p, int len) :
+		call(* PushbackInputStream+.unread(byte[], int, int)) && target(p) &&
+		args(.., len) &&
+		condition(pos < len) {
+	}
+
+	ere : create (read1 | read2 | safeunread)*
+
+	@fail {
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "unread() cannot be performed because the internal pushback buffer is full.");
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/RandomAccessFile_ManipulateAfterClose.mop
+++ b/scripts/javamop-agent-bundle/props/RandomAccessFile_ManipulateAfterClose.mop
@@ -1,0 +1,36 @@
+package mop;
+
+import java.io.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if a closed object performs input or output operations.
+ *
+ * According to the documentation, a closed random access file cannot perform
+ * input or output operations and cannot be reopened.
+ * http://download.oracle.com/javase/6/docs/api/java/io/RandomAccessFile.html#close%28%29
+ *
+ * This property captures only input or output operations performed after
+ * close(), because reopening a file is prevented by the language.
+ *
+ * @severity error
+ */
+
+RandomAccessFile_ManipulateAfterClose(RandomAccessFile f) {
+	event manipulate before(RandomAccessFile f) :
+		(
+			call(* RandomAccessFile+.read*(..)) ||
+			call(* RandomAccessFile+.write*(..))
+		) && target(f) {}
+	creation event close before(RandomAccessFile f) :
+		call(* RandomAccessFile+.close(..)) && target(f) {}
+
+	ere : close+ manipulate+
+
+	@match {
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "A closed random access file cannot perform input or output operations.");
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/Random_OverrideNext.mop
+++ b/scripts/javamop-agent-bundle/props/Random_OverrideNext.mop
@@ -1,0 +1,35 @@
+package mop;
+
+import java.util.*;
+import java.lang.reflect.*;
+import org.aspectj.lang.Signature;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if a Random subclass does not override next(int).
+ *
+ * A subclass of Random should override next(int), according to the
+ * documentation.
+ * http://docs.oracle.com/javase/6/docs/api/java/util/Random.html#next%28int%29
+ *
+ * @severity warning
+ */
+
+Random_OverrideNext() {
+	event staticinit after() : staticinitialization(Random+) {
+		Signature initsig = __STATICSIG;
+		Class klass = initsig.getDeclaringType();		
+
+		if (klass != null) {
+			try {
+				Method nextmethod = klass.getDeclaredMethod("next", int.class);
+			}
+			catch (NoSuchMethodException e) {
+				RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+				RVMLogging.out.println(Level.CRITICAL, klass.getName() + " does not override int next(int bits).");
+			}
+		}
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/Reader_ManipulateAfterClose.mop
+++ b/scripts/javamop-agent-bundle/props/Reader_ManipulateAfterClose.mop
@@ -1,0 +1,38 @@
+package mop;
+
+import java.io.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns read(), ready(), mark(), reset() or skip() after close().
+ *
+ * According to the Reader.close() documentation, read(), ready(), mark(),
+ * reset() or skip() invocations will throw an IOException, once the stream
+ * has been closed.
+ * http://download.oracle.com/javase/6/docs/api/java/io/Reader.html#close%28%29
+ *
+ * This property warns if a closed Reader object invokes the aforementioned
+ * methods.
+ *
+ * @severity error
+ */
+
+Reader_ManipulateAfterClose(Reader r) {
+	event manipulate before(Reader r) :
+		(
+			call(* Reader+.read(..)) ||
+			call(* Reader+.ready(..)) ||
+			call(* Reader+.mark(..)) ||
+			call(* Reader+.reset(..)) ||
+			call(* Reader+.skip(..))
+		) && target(r) {}
+	creation event close before(Reader r) : call(* Reader+.close(..)) && target(r) {}
+
+	ere : close+ manipulate+
+
+	@match {
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "read(), ready(), mark(), reset() or skip() was invoked after close().");
+	}
+}

--- a/scripts/javamop-agent-bundle/props/Reader_MarkReset.mop
+++ b/scripts/javamop-agent-bundle/props/Reader_MarkReset.mop
@@ -1,0 +1,34 @@
+package mop;
+
+import java.io.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Prevents invocations of mark() if the Reader does not support.
+ *
+ * Some subclasses of Reader do not support mark() and reset().
+ * http://download.oracle.com/javase/6/docs/api/java/io/Reader.html#mark%28int%29
+ *
+ * PushbackReader, InputStreamReader, FileReader and PipedReader do not
+ * support mark() and reset(). This specification warns if mark() or reset()
+ * is invoked.
+ *
+ * @severity error
+ */
+
+Reader_MarkReset() {
+	event mark before(Reader+ r) : 
+		call(* Reader+.mark(..)) && target(r) 
+		&& (target(PushbackReader) || target(InputStreamReader) || target(FileReader) || target(PipedReader)){
+			RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+			RVMLogging.out.println(Level.CRITICAL, "PushbackReader, InputStreamReader, FileReader and PipedReader do not support mark() and reset().");
+		}
+
+	event reset before(Reader+ r) : 
+		call(* Reader+.reset(..)) && target(r)
+		&& (target(PushbackReader) || target(InputStreamReader) || target(FileReader) || target(PipedReader)){
+			RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+			RVMLogging.out.println(Level.CRITICAL, "PushbackReader, InputStreamReader, FileReader and PipedReader do not support mark() and reset().");
+		}
+}

--- a/scripts/javamop-agent-bundle/props/Reader_ReadAheadLimit.mop
+++ b/scripts/javamop-agent-bundle/props/Reader_ReadAheadLimit.mop
@@ -1,0 +1,88 @@
+package mop;
+
+import java.io.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Raises an error if mark() is invalidated by reading.
+ *
+ * Some subclasses of Reader support mark() but the mark position can be
+ * invalidated.
+ * http://download.oracle.com/javase/6/docs/api/java/io/Reader.html#reset%28%29
+ *
+ * BufferedReader and LineNumberReader support mark() and reset(), but after
+ * reading the specified number of bytes, the mark is not preserved and,
+ * consequently, calling reset() is prevented.
+ *
+ * This specification keeps track of validity of the mark, and raises an error
+ * when the mark is invalidated and read() is invoked.
+ *
+ * @severity error
+ */
+
+Reader_ReadAheadLimit(Reader r) {
+	int limit = 0;
+	int rest = 0;
+	String LOC = null;
+
+	event mark before(Reader r, int l) :
+		call(* Reader+.mark(int)) && target(r) && args(l) && if (
+			r instanceof BufferedReader ||
+			r instanceof LineNumberReader
+		) {
+		this.limit = l;
+		this.rest = l;
+	}
+
+	event read1 after(Reader r) returning(int n) :
+		call(* Reader+.read()) && target(r) && if (
+			r instanceof BufferedReader ||
+			r instanceof LineNumberReader
+		) {
+		if (n != -1) {
+			this.rest -= 1;
+			if (this.rest < 0)
+				this.LOC = __LOC;
+		}
+	}
+
+	event readn after(Reader r) returning(int n) :
+		call(* Reader+.read(char[], ..)) && target(r) && if (
+			r instanceof BufferedReader ||
+			r instanceof LineNumberReader
+		) {
+		if (n != -1) {
+			this.rest -= n;
+			if (this.rest < 0)
+				this.LOC = __LOC;
+		}
+	}
+
+	event badreset before(Reader r) :
+		call(* Reader+.reset(..)) && target(r) && condition(rest < 0) && if (
+			r instanceof BufferedReader ||
+			r instanceof LineNumberReader
+		) {
+		this.limit = 0;
+		this.rest = 0;
+	}
+
+	event goodreset before(Reader r) :
+		call(* Reader+.reset(..)) && target(r) && condition(rest >= 0) && if (
+			r instanceof BufferedReader ||
+			r instanceof LineNumberReader
+		) {
+		this.rest = this.limit;
+	}
+
+	ere : (mark | read1 | readn | goodreset)* badreset+
+
+	@match {
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "The position mark has been invalidated.");
+		if (this.LOC != null) {
+			RVMLogging.out.println(Level.CRITICAL, "read() at line " + this.LOC + " invalidated the mark.");
+		}
+	}
+}

--- a/scripts/javamop-agent-bundle/props/Reader_UnmarkedReset.mop
+++ b/scripts/javamop-agent-bundle/props/Reader_UnmarkedReset.mop
@@ -1,0 +1,38 @@
+package mop;
+
+import java.io.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Prevents premature invocations of reset().
+ *
+ * Some subclasses of Reader allows reset() only after mark() is called.
+ * http://download.oracle.com/javase/6/docs/api/java/io/Reader.html#reset%28%29
+ *
+ * BufferedReader and LineNumberReader allow reset() only after mark() has
+ * been invoked. This specification catches the violation of this.
+ *
+ * @severity error
+ */
+
+Reader_UnmarkedReset(Reader r) {
+	event mark before(Reader r) : 
+		call(* Reader+.mark(..)) && target(r) && if (
+			r instanceof BufferedReader ||
+			r instanceof LineNumberReader
+		) {}
+
+	event reset before(Reader r) : 
+		call(* Reader+.reset(..)) && target(r) && if (
+			r instanceof BufferedReader ||
+			r instanceof LineNumberReader
+		) {}
+
+	ere : mark (mark | reset)*
+
+	@fail {
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "BufferedReader and LineNumberReader allow reset() only after mark() has been invoked.");
+	}
+}

--- a/scripts/javamop-agent-bundle/props/ResourceBundleControl_MutateFormatList.mop
+++ b/scripts/javamop-agent-bundle/props/ResourceBundleControl_MutateFormatList.mop
@@ -1,0 +1,41 @@
+package mop;
+
+import java.util.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if a list returned by ResourceBundle.Control.getFormats() or
+ * getCandidateLocales() is mutated.
+ *
+ * The List object returned by ResourceBundle.Control.getFormats() or
+ * getCandidateLocales() must not be mutated.
+ * http://docs.oracle.com/javase/6/docs/api/java/util/ResourceBundle.Control.html#getFormats%28java.lang.String%29
+ * http://docs.oracle.com/javase/6/docs/api/java/util/ResourceBundle.Control.html#getCandidateLocales%28java.lang.String,%20java.util.Locale%29
+ *
+ * @severity error
+ */
+
+ResourceBundleControl_MutateFormatList(List l) {
+	creation event create after() returning(List l) :
+		(
+			call(List ResourceBundle.Control.getFormats(..)) ||
+			call(List ResourceBundle.Control.getCandidateLocales(..))
+		) {}
+
+	event mutate before(List l) :
+		(
+			call(* Collection+.add*(..)) ||
+			call(* Collection+.clear(..)) ||
+			call(* Collection+.remove*(..)) ||
+			call(* Collection+.retain*(..))
+		) && target(l) {}
+
+	ere : create mutate
+
+	@match {
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "The list returned by ResourceBundle.Control.getFormats() or getCandidateLocales() was mutated.");
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/Runnable_OverrideRun.mop
+++ b/scripts/javamop-agent-bundle/props/Runnable_OverrideRun.mop
@@ -1,0 +1,33 @@
+package mop;
+
+import java.io.*;
+import java.lang.*;
+import java.lang.reflect.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if a class is runnable without overriding run() method.
+ *
+ * According to the manual, runnable class must provide its own run() method.
+ * http://docs.oracle.com/javase/6/docs/api/java/lang/Runnable.html
+ *
+ * @severity error
+ */
+Runnable_OverrideRun() {
+	event staticinit after() : staticinitialization(Runnable+) {
+		org.aspectj.lang.Signature initsig = __STATICSIG;
+		Class klass = initsig.getDeclaringType();		
+
+		if (klass != null) {
+			Method m;
+			try{
+				m = klass.getMethod("run");
+			} catch (NoSuchMethodException e){
+				RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+				RVMLogging.out.println(Level.CRITICAL, "A Runnable class should provide/override run() method.");
+			}
+		}
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/RuntimePermission_NullAction.mop
+++ b/scripts/javamop-agent-bundle/props/RuntimePermission_NullAction.mop
@@ -1,0 +1,24 @@
+package mop;
+
+import java.io.*;
+import java.lang.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if actions in the constructor of RuntimePermission is not null.
+ *
+ * According to the manual, the actions string is currently unused and should be null. 
+ * http://docs.oracle.com/javase/6/docs/api/java/lang/RuntimePermission.html#RuntimePermission%28java.lang.String,%20java.lang.String%29
+ *
+ * @severity warning
+ */
+ 
+RuntimePermission_NullAction() {
+	event constructor_runtimeperm after(String name, String actions) returning(RuntimePermission r): 
+		call(RuntimePermission.new(String, String)) && args(name, actions) && condition(actions != null) {
+			RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+			RVMLogging.out.println(Level.CRITICAL, "The actions string should be null.");
+		}
+}
+

--- a/scripts/javamop-agent-bundle/props/RuntimePermission_PermName.mop
+++ b/scripts/javamop-agent-bundle/props/RuntimePermission_PermName.mop
@@ -1,0 +1,33 @@
+package mop;
+
+import java.io.*;
+import java.lang.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if permission name is not in the format.
+ *
+ * According to the manual, an asterisk may appear at the end of the name, following a "."
+ * or by itself.
+ * http://docs.oracle.com/javase/6/docs/api/java/lang/RuntimePermission.html
+ *
+ * @severity error
+ */
+ 
+RuntimePermission_PermName() {
+	event constructor_runtimeperm after(String name) returning(RuntimePermission r): 
+		call(RuntimePermission.new(String)) && args(name) {
+			int index = name.indexOf("*");
+			if(index != -1 && name.length() > 1){
+				if(index != name.length() - 1){
+					RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+					RVMLogging.out.println(Level.CRITICAL, "The permission name for RuntimePermission is invalid");
+				} else if (name.charAt(index - 1) != '.'){
+					RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+					RVMLogging.out.println(Level.CRITICAL, "The permission name for RuntimePermission is invalid");
+				}
+			}
+		}
+}
+

--- a/scripts/javamop-agent-bundle/props/Scanner_ManipulateAfterClose.mop
+++ b/scripts/javamop-agent-bundle/props/Scanner_ManipulateAfterClose.mop
@@ -1,0 +1,57 @@
+package mop;
+
+import java.util.*;
+import java.io.*;
+import java.nio.channels.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if a Closeable object, used in Scanner, is used after the Scanner
+ * object is closed.
+ *
+ * A Scanner object can take a Closeable object, such as Readable, InputStream
+ * and ReadableByteChannel, and uses it as input. When the Scanner object is
+ * closed, the Closeable object is closed as well. Thus any further operations
+ * on the Closeable object is prohibited.
+ * http://docs.oracle.com/javase/6/docs/api/java/util/Scanner.html
+ *
+ * This property warns if any method invocation on the Closeable object once
+ * the object is passed to a Scanner object. This does not give false warning
+ * during the execution of Scanner because the callsite is hidden in the
+ * Scanner implementation.
+ *
+ * @severity error
+ */
+
+Scanner_ManipulateAfterClose(Scanner s, Closeable c) {
+	creation event create after(Closeable c) returning(Scanner s) :
+		(
+			call(Scanner+.new(InputStream, ..)) ||
+			call(Scanner+.new(Readable, ..)) ||
+			call(Scanner+.new(ReadableByteChannel, ..))
+		) && args(c, ..) {}
+
+	event close after(Scanner s) :
+		call(* Scanner+.close()) && target(s) &&
+		!args(ByteArrayInputStream) && !args(StringBufferInputStream) {}
+
+	event manipulate before(Closeable c) :
+		(
+			call(* InputStream+.read(..)) ||
+			call(* InputStream+.available(..)) ||
+			call(* InputStream+.reset(..)) ||
+			call(* InputStream+.skip(..)) ||
+			call(* Readable+.read(..)) ||
+			call(* ReadableByteChannel+.read(..))
+		) && target(c) &&
+		!target(ByteArrayInputStream) && !target(StringBufferInputStream) {}
+
+	ere : create close+ manipulate
+
+	@match {
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "The source stream or reader was used after the Scanner had been closed.");
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/Scanner_SearchAfterClose.mop
+++ b/scripts/javamop-agent-bundle/props/Scanner_SearchAfterClose.mop
@@ -1,0 +1,36 @@
+package mop;
+
+import java.util.*;
+import java.io.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if a closed Scanner object attempts to perform search operations.
+ *
+ * http://docs.oracle.com/javase/6/docs/api/java/util/Scanner.html#close%28%29
+ *
+ * @severity error
+ */
+
+Scanner_SearchAfterClose(Scanner s) {
+	creation event close before(Scanner s) :
+		call(* Scanner+.close(..)) && target(s) {}
+
+	event search before(Scanner s) :
+		(
+			call(* Scanner+.find*(..)) ||
+			call(* Scanner+.has*(..)) ||
+			call(* Scanner+.match(..)) ||
+			call(* Scanner+.next*(..)) ||
+			call(* Scanner+.skip(..))
+		) && target(s) {}
+
+	ere : close+ search+
+
+	@match {
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "A closed Scanner object attempted to perform search operations.");
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/SecurityManager_Permission.mop
+++ b/scripts/javamop-agent-bundle/props/SecurityManager_Permission.mop
@@ -1,0 +1,32 @@
+package mop;
+
+import java.io.*;
+import java.lang.*;
+import java.security.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if the context argument to checkPermission method is not from getSecurityContext method call. 
+ *
+ * According to the manual, the context must be a security context returned by a previous call to getSecurityContext.
+ * http://docs.oracle.com/javase/6/docs/api/java/lang/SecurityManager.html#checkPermission%28java.security.Permission,%20java.lang.Object%29
+ *
+ * @severity error
+ */
+SecurityManager_Permission(SecurityManager manager, Object context) {
+	event get after(SecurityManager manager) returning(Object context) :
+		call (* SecurityManager.getSecurityContext(..)) && target(manager){
+		}
+
+	event check before(SecurityManager manager, Object context) : 
+		call(* SecurityManager.checkPermission(Permission, Object)) && target(manager) && args(.., context) {
+		}
+
+	ere: get (get | check)*
+	@fail{
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "The context argument to checkPermission must come from getSecurityContext method call.");
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/Serializable_NoArgConstructor.mop
+++ b/scripts/javamop-agent-bundle/props/Serializable_NoArgConstructor.mop
@@ -1,0 +1,67 @@
+package mop;
+
+import java.io.*;
+import java.lang.reflect.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if a class is serializable, its superclass is not serializable, and
+ * the class cannot access the superclass' no-arg constructor.
+ *
+ * To allow subtypes of non-serializable classes to be serialized, the subtype
+ * may assume responsibility for saving and restoring the state of the
+ * supertype's public, protected, and (if accessible) package fields. The
+ * subtype may assume this responsibility only if the class it extends has an
+ * accessible no-arg constructor to initialize the class's state. It is an
+ * error to declare a class Serializable if this is not the case.
+ * http://download.oracle.com/javase/6/docs/api/java/io/Serializable.html
+ *
+ * This property detects such error.
+ *
+ * @severity error
+ */
+Serializable_NoArgConstructor() {
+	private String getPackageName(Class cl) {
+		String s = cl.getName();
+		int i = s.lastIndexOf('[');
+		if (i >= 0)
+			s = s.substring(i + 2);
+		i = s.lastIndexOf('.');
+		return (i >= 0) ? s.substring(0, i) : "";
+	}
+
+	event staticinit after() : staticinitialization(Serializable+) {
+		org.aspectj.lang.Signature initsig = __STATICSIG;
+		Class klass = initsig.getDeclaringType();		
+
+		if (klass != null) {
+			Class nonserialzable = klass;
+			while (Serializable.class.isAssignableFrom(nonserialzable)) {
+				nonserialzable = nonserialzable.getSuperclass();
+				if (nonserialzable == null)
+					break;
+			}
+
+			if (nonserialzable != null) {
+				boolean samepackage = klass.getClassLoader() == nonserialzable.getClassLoader() &&
+					getPackageName(klass).equals(getPackageName(nonserialzable));
+
+				boolean inaccessible = true;
+				try {
+					Constructor ctor = nonserialzable.getDeclaredConstructor((Class[]) null);
+					int mod = ctor.getModifiers();
+					inaccessible = (mod & Modifier.PRIVATE) != 0 ||
+						((mod & (Modifier.PUBLIC | Modifier.PROTECTED)) == 0 && !samepackage);
+				}
+				catch (NoSuchMethodException e) {
+				}
+				if (inaccessible) {
+					RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+					RVMLogging.out.println(Level.CRITICAL, "The superclass of " + klass.getName() + " does not have an accessible no-arg constructor.");
+				}
+			}
+		}
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/ServerSocket_Backlog.mop
+++ b/scripts/javamop-agent-bundle/props/ServerSocket_Backlog.mop
@@ -1,0 +1,41 @@
+package mop;
+
+import java.net.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if a ServerSocket object is constructed with an invalid backlog
+ * value.
+ *
+ * The backlog argument must be a positive value greater than 0. If the value
+ * passed if equal or less than 0, then the default value will be assumed.
+ * http://docs.oracle.com/javase/6/docs/api/java/net/ServerSocket.html#ServerSocket%28int,%20int%29
+ *
+ * @severity warning
+ */
+ServerSocket_Backlog() {
+	private void check(int backlog, String msg) {
+		if (backlog > 0)
+			return;
+
+		RVMLogging.out.println(Level.CRITICAL, msg);
+		RVMLogging.out.println(Level.CRITICAL, "The backlog argument " + backlog + " is invalid; it should be greater than 0.");
+	}
+
+	event construct before(int backlog) :
+		(
+			call(ServerSocket.new(int, int)) ||
+			call(ServerSocket.new(int, int, InetAddress))
+		) && args(*, backlog, ..)
+	{
+		this.check(backlog, __DEFAULT_MESSAGE);
+	}
+
+	event set before(int backlog) :
+		call(* ServerSocket+.bind(SocketAddress, int)) && args(*, backlog)
+	{
+		this.check(backlog, __DEFAULT_MESSAGE);
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/ServerSocket_LargeReceiveBuffer.mop
+++ b/scripts/javamop-agent-bundle/props/ServerSocket_LargeReceiveBuffer.mop
@@ -1,0 +1,41 @@
+package mop;
+
+import java.net.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if a large receive buffer is set after the server socket is bound.
+ *
+ * It is possible to change the value subsequently, by calling
+ * ServerSocket.setReceiveBufferSize(int). However, if the application wishes
+ * to allow a receive window larger than 64K bytes, as defined by RFC1323 then
+ * the proposed value must be set in the ServerSocket before it is bound to a
+ * local address.
+ * http://docs.oracle.com/javase/6/docs/api/java/net/ServerSocket.html#setReceiveBufferSize%28int%29
+ *
+ * @severity error
+ */
+
+ServerSocket_LargeReceiveBuffer(ServerSocket sock) {
+	creation event create_bound after() returning(ServerSocket sock) :
+		call(ServerSocket.new(int, ..)) {}
+
+	creation event create_unbound after() returning(ServerSocket sock) :
+		call(ServerSocket.new()) {}
+
+	event bind before(ServerSocket sock) :
+		call(* ServerSocket+.bind(..)) && target(sock) {}
+
+	event set before(ServerSocket sock, int size) :
+		call(* ServerSocket+.setReceiveBufferSize(int)) &&
+		target(sock) && args(size) && condition(size > 65536) {}
+
+	ere : (create_bound | create_unbound set* bind+) set
+
+	@match {
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "A receive window large than 64K bytes must be set before the server socket is bound.");
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/ServerSocket_PerformancePreferences.mop
+++ b/scripts/javamop-agent-bundle/props/ServerSocket_PerformancePreferences.mop
@@ -1,0 +1,38 @@
+package mop;
+
+import java.net.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if ServerSocket.setPerformancePreferences() is invoked after the
+ * socket has been bound.
+ *
+ * Invoking ServerSocket.setPerformancePreferences() after the socket has been
+ * bound will have no effect.
+ * http://docs.oracle.com/javase/6/docs/api/java/net/ServerSocket.html#setPerformancePreferences%28int,%20int,%20int%29
+ *
+ * @severity warning
+ */
+
+ServerSocket_PerformancePreferences(ServerSocket sock) {
+	creation event create_bound after() returning(ServerSocket sock) :
+		call(ServerSocket.new(int, ..)) {}
+
+	creation event create_unbound after() returning(ServerSocket sock) :
+		call(ServerSocket.new()) {}
+
+	event bind before(ServerSocket sock) :
+		call(* ServerSocket+.bind(..)) && target(sock) {}
+
+	event set before(ServerSocket sock) :
+		call(* ServerSocket+.setPerformancePreferences(..)) && target(sock) {}
+
+	ere : (create_bound | create_unbound set* bind+) set
+
+	@match {
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "Invoking ServerSocket.setPerformancePreferences() after the socket has been bound will have no effect.");
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/ServerSocket_Port.mop
+++ b/scripts/javamop-agent-bundle/props/ServerSocket_Port.mop
@@ -1,0 +1,32 @@
+package mop;
+
+import java.net.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if a ServerSocket object is created with an invalid port.
+ *
+ * The port, a parameter of some ServerSocket's constructors, must be between
+ * 0 and 65535 inclusive.
+ * http://docs.oracle.com/javase/6/docs/api/java/net/ServerSocket.html#ServerSocket%28int,%20int,%20java.net.InetAddress%29
+ *
+ * @severity error
+ */
+
+ServerSocket_Port() {
+	event construct_port before(int port) :
+		(
+			call(ServerSocket.new(int)) ||
+			call(ServerSocket.new(int, int)) ||
+			call(ServerSocket.new(int, int, InetAddress))
+		) && args(port, ..)
+	{
+		if (0 <= port && port <= 65535)
+			return;
+
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "The specified port " + port + " is out of range; [0 ~ 65535]");
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/ServerSocket_ReuseAddress.mop
+++ b/scripts/javamop-agent-bundle/props/ServerSocket_ReuseAddress.mop
@@ -1,0 +1,37 @@
+package mop;
+
+import java.net.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if SO_REUSEADDR is enabled or disabled after a ServerSocket is bound.
+ *
+ * The behavior when SO_REUSEADDR is enabled or disabled after a socket is
+ * bound is not defined.
+ * http://docs.oracle.com/javase/6/docs/api/java/net/ServerSocket.html#setReuseAddress%28boolean%29
+ *
+ * @severity warning
+ */
+
+ServerSocket_ReuseAddress(ServerSocket sock) {
+	creation event create_bound after() returning(ServerSocket sock) :
+		call(ServerSocket.new(int, ..)) {}
+
+	creation event create_unbound after() returning(ServerSocket sock) :
+		call(ServerSocket.new()) {}
+
+	event bind before(ServerSocket sock) :
+		call(* ServerSocket+.bind(..)) && target(sock) {}
+
+	event set before(ServerSocket sock) :
+		call(* ServerSocket+.setReuseAddress(..)) && target(sock) {}
+
+	ere : (create_bound | create_unbound set* bind+) set
+
+	@match {
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "The behavior of setting SO_REUSEADDR after a socket is bound is not defined.");
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/ServerSocket_SetTimeoutBeforeBlocking.mop
+++ b/scripts/javamop-agent-bundle/props/ServerSocket_SetTimeoutBeforeBlocking.mop
@@ -1,0 +1,36 @@
+package mop;
+
+import java.net.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if the timeout option is set after the blocking operation starts.
+ *
+ * The timeout option must be enabled prior to entering the blocking operation
+ * to have effect.
+ * http://docs.oracle.com/javase/6/docs/api/java/net/ServerSocket.html#setSoTimeout%28int%29
+ *
+ * @severity warning
+ */
+ServerSocket_SetTimeoutBeforeBlocking(ServerSocket sock) {
+	creation event enter before(ServerSocket sock) :
+		call(* ServerSocket+.accept(..)) && target(sock) {}
+
+	event leave after(ServerSocket sock) :
+		call(* ServerSocket+.accept(..)) && target(sock) {}
+
+	event set before(ServerSocket sock, int timeout) :
+		call(* ServerSocket+.setSoTimeout(int)) && target(sock) && args(timeout)
+		&& condition(timeout != 0) {}
+
+	ere : set* (enter leave)* set*
+
+	@fail {
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "ServerSocket.setSoTimeout() should be set prior to entering the blocking operation.");
+
+		__RESET;
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/ServerSocket_Timeout.mop
+++ b/scripts/javamop-agent-bundle/props/ServerSocket_Timeout.mop
@@ -1,0 +1,26 @@
+package mop;
+
+import java.net.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if an invalid timeout value is set to a ServerSocket object.
+ *
+ * The timeout value must be > 0.
+ * http://docs.oracle.com/javase/6/docs/api/java/net/ServerSocket.html#setSoTimeout%28int%29
+ *
+ * @severity error
+ */
+ServerSocket_Timeout() {
+	event set before(int timeout) :
+		call(* ServerSocket+.setSoTimeout(int)) && args(timeout)
+	{
+		if (timeout > 0)
+			return;
+
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "An invalid timeout value " + timeout + " was set to a ServerSocket object.");
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/ServiceLoaderIterator_Remove.mop
+++ b/scripts/javamop-agent-bundle/props/ServiceLoaderIterator_Remove.mop
@@ -1,0 +1,31 @@
+package mop;
+
+import java.util.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if an iterator from a ServiceLoader object attempts to invoke
+ * remove().
+ *
+ * The iterator returned by ServiceLoader.iterator() does not support removal.
+ * http://docs.oracle.com/javase/6/docs/api/java/util/ServiceLoader.html#iterator%28%29
+ *
+ * @severity error
+ */
+
+ServiceLoaderIterator_Remove(Iterator i) {
+	creation event create after(ServiceLoader s) returning(Iterator i) :
+		call(Iterator ServiceLoader.iterator()) && target(s) {}
+
+	event remove before(Iterator i) :
+		call(* Iterator+.remove(..)) && target(i) {}
+
+	ere : create remove
+
+	@match {
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "The iterator returned by ServiceLoader.iterator() does not support removal.");
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/ServiceLoader_MultipleConcurrentThreads.mop
+++ b/scripts/javamop-agent-bundle/props/ServiceLoader_MultipleConcurrentThreads.mop
@@ -1,0 +1,48 @@
+package mop;
+
+import java.util.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if a ServiceLoader object is used by multiple threads.
+ *
+ * Instances of ServiceLoader class are not safe for use by multiple
+ * concurrent threads.
+ * http://docs.oracle.com/javase/6/docs/api/java/util/ServiceLoader.html
+ *
+ * This property warns if a ServiceLoader object is ever used by multiple
+ * threads. This condition is harsher than the documentation in the sense that
+ * this property warns non-concurrent use of the object.
+ *
+ * @severity warning
+ */
+
+ServiceLoader_MultipleConcurrentThreads(ServiceLoader s) {
+	Thread t;
+	
+	creation event create after(Thread t2) returning(ServiceLoader s) :
+		call(ServiceLoader ServiceLoader+.load*(..)) && thread(t2) {
+			this.t = t2; 
+		}
+
+	event gooduse before(ServiceLoader s, Thread t2) :
+		(
+			call(* ServiceLoader+.iterator()) ||
+			call(* ServiceLoader+.reload())
+		) && target(s) && thread(t2) && condition(this.t == t2) {}
+
+	event baduse before(ServiceLoader s, Thread t2) :
+		(
+			call(* ServiceLoader+.iterator()) ||
+			call(* ServiceLoader+.reload())
+		) && target(s) && thread(t2) && condition(this.t != t2) {}
+
+	ere : create gooduse* baduse
+
+	@match {
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "A ServiceLoader object has been used by multiple threads.");
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/Set_ItselfAsElement.mop
+++ b/scripts/javamop-agent-bundle/props/Set_ItselfAsElement.mop
@@ -1,0 +1,41 @@
+package mop;
+
+import java.util.*;
+import java.lang.reflect.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if a subclass of Set contains itself as an element.
+ *
+ * The behavior of a set is not specified if the value of an object is changed
+ * in a manner that affects equals() comparisons while the object is an
+ * element in the set. A special case of this prohibition is that it is not
+ * permissible for a set to contain itself as an element.
+ * http://docs.oracle.com/javase/6/docs/api/java/util/Set.html
+ *
+ * This property checks if the special case: a set contains itself by
+ * capturing add() and addAll(). It is hard to detect whether or not equals()
+ * comparisons are affected.
+ *
+ * @severity error
+ */
+
+Set_ItselfAsElement() {
+	event add before(Set s, Object elem) :
+		call(* Set+.add(Object)) && target(s) && args(elem) && condition(elem == s){
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "A set cannot contain itself as an element.");
+	}
+
+	event addall before(Set s, Collection src) :
+		call(* Set+.addAll(Collection)) && target(s) && args(src) {
+		for (Object elem : src) {
+			if (elem == s) {
+				RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+				RVMLogging.out.println(Level.CRITICAL, "A set cannot contain itself as an element.");
+			}
+		}
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/Short_BadDecodeArg.mop
+++ b/scripts/javamop-agent-bundle/props/Short_BadDecodeArg.mop
@@ -1,0 +1,68 @@
+package mop;
+
+import java.io.*;
+import java.lang.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns when the argument to decode is wrong
+ *
+ * According to the manual, the argument cannot contain any whitespace.
+ * Also, there is a format to follow. 
+ * http://docs.oracle.com/javase/6/docs/api/java/lang/Short.html#decode%28java.lang.String%29
+ *
+ * @severity error
+ */
+Short_BadDecodeArg() {
+
+    event decode before(Short s, String nm) : 
+        call(* Short.decode(String)) && args(nm) && target(s){
+        if(nm == null || nm.length() == 0){
+            RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+            RVMLogging.out.println(Level.CRITICAL, "Wrong argument to Short.decode(String nm)");
+        } else {
+            //whitespace check
+            for(int j = 0; j < nm.length(); j++){
+                if(Character.isWhitespace(nm.charAt(j))){
+                    RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+                    RVMLogging.out.println(Level.CRITICAL, "Wrong argument to Short.decode(String nm)");
+                }
+            }
+            
+            //formatcheck
+            String sub;
+            if(nm.charAt(0) == '-'){
+                sub = nm.substring(1);
+            } else {
+                sub = nm;
+            }
+            
+            int radix = 0;
+            if(sub.startsWith("0x") || sub.startsWith("0X")){
+                sub = sub.substring(2);
+                radix = 16;
+            } else if(sub.startsWith("#")){
+                sub = sub.substring(1);
+                radix = 16;
+            } else if(sub.startsWith("0")){
+                sub = sub.substring(1);
+                radix = 8;
+            } else {
+                radix = 10;
+            }
+            
+            try{
+                if(Short.parseShort(sub, radix) < 0){
+                    RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+                    RVMLogging.out.println(Level.CRITICAL, "Wrong argument to Short.decode(String nm)");
+                }
+            } catch(Exception e){
+                RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+                RVMLogging.out.println(Level.CRITICAL, "Wrong argument to Short.decode(String nm)");
+            }
+            
+        }
+    }
+}
+

--- a/scripts/javamop-agent-bundle/props/Short_BadParsingArgs.mop
+++ b/scripts/javamop-agent-bundle/props/Short_BadParsingArgs.mop
@@ -1,0 +1,56 @@
+package mop;
+
+import java.io.*;
+import java.lang.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns when arguments to parseShort are wrong.
+ *
+ * According to the manual, the first argument cannot be null or of length zero.
+ * Also, radix should be in the range.
+ * http://docs.oracle.com/javase/6/docs/api/java/lang/Short.html#parseShort%28java.lang.String,%20int%29
+ *
+ * @severity warning
+ */
+Short_BadParsingArgs() {
+	event bad_arg before(String s, int radix) : 
+		call(* Short.parseShort(String, int)) && args(s, radix) {
+			if(s == null || s.length() == 0){
+				RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+				RVMLogging.out.println(Level.CRITICAL, "Wrong argument to Short.parseShort(String s, int radix)");
+			} else if(radix < java.lang.Character.MIN_RADIX || radix > java.lang.Character.MAX_RADIX){
+				RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+				RVMLogging.out.println(Level.CRITICAL, "Wrong argument to Short.parseShort(String s, int radix)");
+			} else {
+				for(int j = 0; j < s.length(); j++){
+					if(Character.digit(s.charAt(j), radix) == -1){
+						if(!(j == 0 && s.length() > 1 && s.charAt(0) == '-')){
+							RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+							RVMLogging.out.println(Level.CRITICAL, "Wrong argument to Short.parseShort(String s, int radix)");
+						}
+					} 
+				}
+			}
+		}
+
+	event bad_arg2 before(String s) : 
+		call(* Short.parseShort(String)) && args(s) {
+			if(s == null || s.length() == 0){
+				RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+				RVMLogging.out.println(Level.CRITICAL, "Wrong argument to Short.parseShort(String s)");
+			} else {
+				for(int j = 0; j < s.length(); j++){
+					if(Character.digit(s.charAt(j), 10) == -1){
+						if(!(j == 0 && s.length() > 1 && s.charAt(0) == '-')){
+							RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+							RVMLogging.out.println(Level.CRITICAL, "Wrong argument to Short.parseShort(String s)");
+						}
+					} 
+				}
+			}
+		}
+		
+}
+

--- a/scripts/javamop-agent-bundle/props/ShutdownHook_LateRegister.mop
+++ b/scripts/javamop-agent-bundle/props/ShutdownHook_LateRegister.mop
@@ -1,0 +1,36 @@
+package mop;
+
+import java.lang.*;
+import java.lang.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if one registers a new shutdown hook after the shutdown sequence has begun.
+ * 
+ * According to the manual, "Once the shutdown sequence has begun it is impossible 
+ * to register a new shutdown hook or de-register a previously-registered hook." 
+ * http://docs.oracle.com/javase/6/docs/api/java/lang/Runtime.html
+ *
+ * @severity error
+ */
+ShutdownHook_LateRegister() {
+	HashSet<Thread> threadSet = new HashSet<Thread>();
+
+	creation event register after(Thread t) : call(* Runtime+.addShutdownHook(..)) && args(t) {
+		threadSet.add(t);
+	}
+	creation event unregister after(Thread t) : call(* Runtime+.removeShutdownHook(..)) && args(t) {
+		threadSet.remove(t);
+	}
+	event start after(Thread t) : startThread() && thread(t) && condition(threadSet.contains(t)) {
+	}
+
+	ere : (register | unregister)* start+ (register | unregister)
+	
+	@match {
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "A shutdown hook was registered/unregister after the shutdown sequence had begun.");
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/ShutdownHook_PrematureStart.mop
+++ b/scripts/javamop-agent-bundle/props/ShutdownHook_PrematureStart.mop
@@ -1,0 +1,47 @@
+package mop;
+
+import java.lang.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Prevents registering a shutdown hook that has been started.
+ *
+ * http://docs.oracle.com/javase/6/docs/api/java/lang/Runtime.html
+ * According to the manual, addShutdownHook() registers a shutdown hook, 
+ * an initialized but unstarted thread that will be started 
+ * when the VM begins the shutdown sequence. 
+ * Since a shutdown hook is started by the VM, it should not be started prematurely
+ * by the user code. This specification captures the premature start.
+ *
+ * @severity error
+ */
+
+ShutdownHook_PrematureStart(Thread t) {
+
+	creation event good_register before(Thread t) : call(* Runtime+.addShutdownHook(..)) && args(t) && condition(t.getState() == Thread.State.NEW) {}
+
+	creation event bad_register before(Thread t) : call(* Runtime+.addShutdownHook(..)) && args(t) && condition(t.getState() != Thread.State.NEW) {}
+
+	event unregister before(Thread t) : call(* Runtime+.removeShutdownHook(..)) && args(t) {}
+
+	event userstart before(Thread t) : call(* Thread+.start(..)) && target(t) {}
+
+	fsm :
+		unregistered [
+			good_register -> registered
+			bad_register -> err
+		]
+		registered [
+			unregister -> unregistered
+			userstart -> err
+		]
+		err [
+		]
+
+	@err {
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "A virtual-machine shutdown hook has been started by the user code.");
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/ShutdownHook_SystemExit.mop
+++ b/scripts/javamop-agent-bundle/props/ShutdownHook_SystemExit.mop
@@ -1,0 +1,49 @@
+package mop;
+
+import java.lang.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if a shutdown hook attempts to call exit().
+ *
+ * According to the manual, calling exit() inside a shutdown hook will block indefinitely.
+ * http://docs.oracle.com/javase/6/docs/api/java/lang/Runtime.html
+ * A shutdown hook, which is started by the VM during the shutdown sequence,
+ * should not invoke System.exit() because it may lead to deadlocks. This
+ * specification nullifies the invocation and outputs an error message,
+ * instead.
+ *
+ * @severity error
+ */
+ShutdownHook_SystemExit(Thread t) {
+	creation event register before(Thread t) : call(* Runtime+.addShutdownHook(..)) && args(t) {}
+	creation event unregister before(Thread t) : call(* Runtime+.removeShutdownHook(..)) && args(t) {}
+	event start before(Thread t) : startThread() && thread(t) {}
+	event exit void around(Thread t) :
+		(
+			call(* System.exit(..))
+		)
+		&& thread(t) {__SKIP;}
+
+	fsm :
+		unregistered [
+			register -> registered
+		]
+		registered [
+			unregister -> unregistered
+			start -> started
+		]
+		started [
+			exit -> unsafe
+		]
+		unsafe [
+			exit -> unsafe
+		]
+
+	@unsafe {
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "Invoking System.exit() in a shutdown hook was suppressed because it may lead to deadlocks.");
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/ShutdownHook_UnsafeAWTCall.mop
+++ b/scripts/javamop-agent-bundle/props/ShutdownHook_UnsafeAWTCall.mop
@@ -1,0 +1,50 @@
+package mop;
+
+import java.lang.*;
+import java.awt.EventQueue;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if a shutdown hook attempts to use thread-based services such as the
+ * AWT event-dispatch thread because it may lead to deadlocks.
+ *
+ * According to the manual, a shutdown hook, which is started by the VM 
+ * during the shutdown sequence, should not use thread-based services, 
+ * in order to avoid deadlocks.
+ * http://docs.oracle.com/javase/6/docs/api/java/lang/Runtime.html
+ *
+ * @severity error
+ */
+ShutdownHook_UnsafeAWTCall(Thread t) {
+	creation event register before(Thread t) : call(* Runtime+.addShutdownHook(..)) && args(t) {}
+	creation event unregister before(Thread t) : call(* Runtime+.removeShutdownHook(..)) && args(t) {}
+	event start before(Thread t) : startThread() && thread(t) {}
+	event awtcall void around(Thread t) :
+		(
+			call(* EventQueue.invokeAndWait(..))
+			|| call(* EventQueue.invokeLater(..))
+		)
+		&& thread(t) {__SKIP;}
+
+	fsm :
+		unregistered [
+			register -> registered
+		]
+		registered [
+			unregister -> unregistered
+			start -> started
+		]
+		started [
+			awtcall -> unsafe
+		]
+		unsafe [
+			awtcall -> unsafe
+		]
+
+	@unsafe {
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "An operation that potentially leads to deadlocks was performed in a shutdown hook.");
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/ShutdownHook_UnsafeSwingCall.mop
+++ b/scripts/javamop-agent-bundle/props/ShutdownHook_UnsafeSwingCall.mop
@@ -1,0 +1,58 @@
+package mop;
+
+import java.lang.*;
+import javax.swing.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if a shutdown hook attempts to use thread-based services such as
+ * SwingUtilities because it may lead to deadlocks.
+ *
+ * According to the manual, a shutdown hook, which is started by the VM 
+ * during the shutdown sequence, should not use thread-based services, 
+ * in order to avoid deadlocks.
+ * http://docs.oracle.com/javase/6/docs/api/java/lang/Runtime.html
+ *
+ * @severity error
+ */
+ShutdownHook_UnsafeSwingCall(Thread t) {
+	creation event register before(Thread t) : call(* Runtime+.addShutdownHook(..)) && args(t) {}
+	creation event unregister before(Thread t) : call(* Runtime+.removeShutdownHook(..)) && args(t) {}
+	event start before(Thread t) : startThread() && thread(t) {}
+	event swingcall1 void around(Thread t) :
+		(
+			call(* SwingUtilities+.invokeAndWait(..))
+			|| call(* SwingUtilities+.invokeLater(..))
+			|| call(* SwingWorker+.execute(..))
+		)
+		&& thread(t) {__SKIP;}
+	event swingcall2 Object around(Thread t) :
+		(
+			call(* SwingWorker+.get(..))
+		)
+		&& thread(t) {__SKIP;}
+
+	fsm :
+		unregistered [
+			register -> registered
+		]
+		registered [
+			unregister -> unregistered
+			start -> started
+		]
+		started [
+			swingcall1 -> unsafe
+			swingcall2 -> unsafe
+		]
+		unsafe [
+			swingcall1 -> unsafe
+			swingcall2 -> unsafe
+		]
+
+	@unsafe {
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "An operation that potentially leads to deadlocks was performed in a shutdown hook.");
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/SocketImpl_CloseOutput.mop
+++ b/scripts/javamop-agent-bundle/props/SocketImpl_CloseOutput.mop
@@ -1,0 +1,38 @@
+package mop;
+
+import java.net.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+import java.io.OutputStream;
+
+/**
+ * Warns if an output stream of a closed socket is used.
+ *
+ * If you write to a socket output stream after invoking shutdownOutput() on
+ * the socket, the stream will throw an IOException. 
+ * http://docs.oracle.com/javase/6/docs/api/java/net/SocketImpl.html#shutdownOutput%28%29
+ *
+ * @severity error
+ */
+
+SocketImpl_CloseOutput(SocketImpl sock, OutputStream output) {
+	creation event getoutput after(SocketImpl sock) returning(OutputStream output) :
+		call(OutputStream SocketImpl+.getOutputStream()) && target(sock) {}
+
+	event close before(SocketImpl sock) :
+		(
+			call(* SocketImpl+.close(..)) ||
+			call(* SocketImpl+.shutdownOutput(..))
+		)  && target(sock) {}
+
+	event use before(OutputStream output) :
+		call(* OutputStream+.*(..)) && target(output) {}
+
+	ere : getoutput close use+
+
+	@match {
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "The output stream of a closed socket is about to be used.");
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/SocketPermission_Actions.mop
+++ b/scripts/javamop-agent-bundle/props/SocketPermission_Actions.mop
@@ -1,0 +1,47 @@
+package mop;
+
+import java.net.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if the 'actions' parameter is invalid.
+ *
+ * The 'actions' parameter contains a comma-separated list of the actions
+ * granted for the specified host (and port(s)). Possible actions are
+ * "connect", "listen", "accept", "resolve", or any combination of those.
+ * "resolve" is automatically added when any of the other three are specified.
+ * http://docs.oracle.com/javase/6/docs/api/java/net/SocketPermission.html#SocketPermission%28java.lang.String,%20java.lang.String%29
+ *
+ * @severity error
+ */
+SocketPermission_Actions() {
+	event construct before(String actions) :
+		call(SocketPermission.new(String, String)) && args(*, actions)
+	{
+		HashSet<String> possible = new HashSet<String>();
+		possible.add("connect");
+		possible.add("listen");
+		possible.add("accept");
+		possible.add("resolve");
+
+		boolean valid = true;
+		String[] split = actions.split(",");
+		if (split.length == 0)
+			valid = false;
+		else {
+			for (String act : split) {
+				if (!possible.contains(act)) {
+					valid = false;
+					break;
+				}
+			}
+		}
+
+		if (!valid) {
+			RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+			RVMLogging.out.println(Level.CRITICAL, "The 'actions' parameter '" + actions + "' is invalid.");
+		}
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/Socket_CloseInput.mop
+++ b/scripts/javamop-agent-bundle/props/Socket_CloseInput.mop
@@ -1,0 +1,38 @@
+package mop;
+
+import java.net.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+import java.io.InputStream;
+
+/**
+ * Warns if an input stream of a closed socket is used.
+ *
+ * Closing a socket will also close the socket's InputStream and OutputStream.
+ * http://docs.oracle.com/javase/6/docs/api/java/net/Socket.html#close%28%29
+ *
+ * This property will see if any operation is performed on a closed socket's
+ * input stream. A closed socket's output stream will be checked by the
+ * companion property of this one.
+ *
+ * @severity error
+ */
+
+Socket_CloseInput(Socket sock, InputStream input) {
+	creation event getinput after(Socket sock) returning(InputStream input) :
+		call(InputStream Socket+.getInputStream()) && target(sock) {}
+
+	event close before(Socket sock) :
+		call(* Socket+.close(..)) && target(sock) {}
+
+	event use before(InputStream input) :
+		call(* InputStream+.*(..)) && target(input) {}
+
+	ere : getinput close use+
+
+	@match {
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "The input stream of a closed socket is about to be used.");
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/Socket_CloseOutput.mop
+++ b/scripts/javamop-agent-bundle/props/Socket_CloseOutput.mop
@@ -1,0 +1,40 @@
+package mop;
+
+import java.net.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+import java.io.OutputStream;
+
+/**
+ * Warns if an output stream of a closed socket is used.
+ *
+ * Closing a socket will also close the socket's InputStream and OutputStream.
+ * http://docs.oracle.com/javase/6/docs/api/java/net/Socket.html#close%28%29
+ *
+ * This property will see if any operation is performed on a closed socket's
+ * output stream. A closed socket's input stream will be checked by the
+ * companion property of this one.
+ *
+ * @severity error
+ */
+
+Socket_CloseOutput(Socket sock, OutputStream output) {
+	creation event getoutput after(Socket sock) returning(OutputStream output) :
+		call(OutputStream Socket+.getOutputStream()) && target(sock) {}
+
+	event close before(Socket sock) :
+		(
+			call(* Socket+.close(..)) ||
+			call(* Socket+.shutdownOutput(..))
+		) && target(sock) {}
+
+	event use before(OutputStream output) :
+		call(* OutputStream+.*(..)) && target(output) {}
+
+	ere : getoutput close use+
+
+	@match {
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "The output stream of a closed socket is about to be used.");
+	}
+}

--- a/scripts/javamop-agent-bundle/props/Socket_InputStreamUnavailable.mop
+++ b/scripts/javamop-agent-bundle/props/Socket_InputStreamUnavailable.mop
@@ -1,0 +1,55 @@
+package mop;
+
+import java.net.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if Socket.getInputStream() is invoked when the input stream is
+ * unavailable.
+ *
+ * An input stream is unavailable if the socket is closed, is not connected,
+ * or the socket input has been shutdown.
+ * http://docs.oracle.com/javase/6/docs/api/java/net/Socket.html#getInputStream%28%29
+ *
+ * @severity error
+ */
+
+Socket_InputStreamUnavailable(Socket sock) {
+	creation event create_connected after() returning(Socket sock) :
+		(
+			call(Socket.new(InetAddress, int)) ||
+			call(Socket.new(InetAddress, int, boolean)) ||
+			call(Socket.new(InetAddress, int, InetAddress, int)) ||
+			call(Socket.new(String, int)) ||
+			call(Socket.new(String, int, boolean)) ||
+			call(Socket.new(String, int, InetAddress, int))
+		) {}
+
+	creation event create_unconnected after() returning(Socket sock) :
+		(
+			call(Socket.new()) ||
+			call(Socket.new(Proxy)) ||
+			call(Socket.new(SocketImpl))
+		) {}
+
+	event connect before(Socket sock) :
+		call(* Socket+.connect(..)) && target(sock) {}
+
+	event get before(Socket sock) :
+		call(* Socket+.getInputStream(..)) && target(sock) {}
+
+	event close before(Socket sock) :
+		call(* Socket+.close()) && target(sock) {}
+
+	event shutdown before(Socket sock) :
+		call(* Socket+.shutdownInput()) && target(sock) {}
+
+	ere : (create_connected | create_unconnected connect) get* (close | shutdown)*
+
+	@fail {
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "An input stream is unavailable if the socket is closed, is not connected, or the socket input has been shutdown.");
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/Socket_LargeReceiveBuffer.mop
+++ b/scripts/javamop-agent-bundle/props/Socket_LargeReceiveBuffer.mop
@@ -1,0 +1,50 @@
+package mop;
+
+import java.net.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if a large receive buffer is set after the socket is connected.
+ *
+ * Generally, the window size can be modified at any time when a socket is
+ * connected. However, if a receive window larger than 64K is required then
+ * this must be requested before the socket is connected to the remote peer.
+ * http://docs.oracle.com/javase/6/docs/api/java/net/Socket.html#setReceiveBufferSize%28int%29
+ *
+ * @severity error
+ */
+
+Socket_LargeReceiveBuffer(Socket sock) {
+	creation event create_connected after() returning(Socket sock) :
+		(
+			call(Socket.new(InetAddress, int)) ||
+			call(Socket.new(InetAddress, int, boolean)) ||
+			call(Socket.new(InetAddress, int, InetAddress, int)) ||
+			call(Socket.new(String, int)) ||
+			call(Socket.new(String, int, boolean)) ||
+			call(Socket.new(String, int, InetAddress, int))
+		) {}
+
+	creation event create_unconnected after() returning(Socket sock) :
+		(
+			call(Socket.new()) ||
+			call(Socket.new(Proxy)) ||
+			call(Socket.new(SocketImpl))
+		) {}
+
+	event connect before(Socket sock) :
+		call(* Socket+.connect(..)) && target(sock) {}
+
+	event set before(Socket sock, int size) :
+		call(* Socket+.setReceiveBufferSize(int)) &&
+		target(sock) && args(size) && condition(size > 65536) {}
+
+	ere : (create_connected | create_unconnected set* connect+) set
+
+	@match {
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "A receive window large than 64K bytes must be set before the socket is connected.");
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/Socket_OutputStreamUnavailable.mop
+++ b/scripts/javamop-agent-bundle/props/Socket_OutputStreamUnavailable.mop
@@ -1,0 +1,54 @@
+package mop;
+
+import java.net.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if Socket.getOutputStream() is invoked when the output stream is
+ * unavailable.
+ *
+ * Although it is not documented, an output stream is unavailable if the
+ * socket is closed, is not connected, or the socket output has been shutdown.
+ *
+ * @severity error
+ */
+
+Socket_OutputStreamUnavailable(Socket sock) {
+	creation event create_connected after() returning(Socket sock) :
+		(
+			call(Socket.new(InetAddress, int)) ||
+			call(Socket.new(InetAddress, int, boolean)) ||
+			call(Socket.new(InetAddress, int, InetAddress, int)) ||
+			call(Socket.new(String, int)) ||
+			call(Socket.new(String, int, boolean)) ||
+			call(Socket.new(String, int, InetAddress, int))
+		) {}
+
+	creation event create_unconnected after() returning(Socket sock) :
+		(
+			call(Socket.new()) ||
+			call(Socket.new(Proxy)) ||
+			call(Socket.new(SocketImpl))
+		) {}
+
+	event connect before(Socket sock) :
+		call(* Socket+.connect(..)) && target(sock) {}
+
+	event get before(Socket sock) :
+		call(* Socket+.getOutputStream(..)) && target(sock) {}
+
+	event close before(Socket sock) :
+		call(* Socket+.close()) && target(sock) {}
+
+	event shutdown before(Socket sock) :
+		call(* Socket+.shutdownOutput()) && target(sock) {}
+
+	ere : (create_connected | create_unconnected connect) get* (close | shutdown)*
+
+	@fail {
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "An output stream is unavailable if the socket is closed, is not connected, or the socket output has been shutdown.");
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/Socket_PerformancePreferences.mop
+++ b/scripts/javamop-agent-bundle/props/Socket_PerformancePreferences.mop
@@ -1,0 +1,49 @@
+package mop;
+
+import java.net.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if ServerSocket.setPerformancePreferences() is invoked after the
+ * socket has been bound.
+ *
+ * Invoking ServerSocket.setPerformancePreferences() after the socket has been
+ * bound will have no effect.
+ * http://docs.oracle.com/javase/6/docs/api/java/net/Socket.html#setPerformancePreferences%28int,%20int,%20int%29
+ *
+ * @severity warning
+ */
+
+Socket_PerformancePreferences(Socket sock) {
+	creation event create_connected after() returning(Socket sock) :
+		(
+			call(Socket.new(InetAddress, int)) ||
+			call(Socket.new(InetAddress, int, boolean)) ||
+			call(Socket.new(InetAddress, int, InetAddress, int)) ||
+			call(Socket.new(String, int)) ||
+			call(Socket.new(String, int, boolean)) ||
+			call(Socket.new(String, int, InetAddress, int))
+		) {}
+
+	creation event create_unconnected after() returning(Socket sock) :
+		(
+			call(Socket.new()) ||
+			call(Socket.new(Proxy)) ||
+			call(Socket.new(SocketImpl))
+		) {}
+
+	event connect before(Socket sock) :
+		call(* Socket+.connect(..)) && target(sock) {}
+
+	event set before(Socket sock) :
+		call(* Socket+.setPerformancePreferences(..)) && target(sock) {}
+
+	ere : (create_connected | create_unconnected set* connect+) set
+
+	@match {
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "Invoking Socket.setPerformancePreferences() after the socket has been bound will have no effect.");
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/Socket_ReuseAddress.mop
+++ b/scripts/javamop-agent-bundle/props/Socket_ReuseAddress.mop
@@ -1,0 +1,48 @@
+package mop;
+
+import java.net.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if SO_REUSEADDR is enabled or disabled after a ServerSocket is bound.
+ *
+ * The behavior when SO_REUSEADDR is enabled or disabled after a socket is
+ * bound is not defined.
+ * http://docs.oracle.com/javase/6/docs/api/java/net/Socket.html#setReuseAddress%28boolean%29
+ *
+ * @severity warning
+ */
+
+Socket_ReuseAddress(Socket sock) {
+	creation event create_connected after() returning(Socket sock) :
+		(
+			call(Socket.new(InetAddress, int)) ||
+			call(Socket.new(InetAddress, int, boolean)) ||
+			call(Socket.new(InetAddress, int, InetAddress, int)) ||
+			call(Socket.new(String, int)) ||
+			call(Socket.new(String, int, boolean)) ||
+			call(Socket.new(String, int, InetAddress, int))
+		) {}
+
+	creation event create_unconnected after() returning(Socket sock) :
+		(
+			call(Socket.new()) ||
+			call(Socket.new(Proxy)) ||
+			call(Socket.new(SocketImpl))
+		) {}
+
+	event bind before(Socket sock) :
+		call(* Socket+.bind(..)) && target(sock) {}
+
+	event set before(Socket sock) :
+		call(* Socket+.setReuseAddress(..)) && target(sock) {}
+
+	ere : (create_connected | create_unconnected set* bind+) set
+
+	@match {
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "The behavior of setting SO_REUSEADDR after a socket is bound is not defined.");
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/Socket_ReuseSocket.mop
+++ b/scripts/javamop-agent-bundle/props/Socket_ReuseSocket.mop
@@ -1,0 +1,35 @@
+package mop;
+
+import java.net.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if a closed socket is about to be reused for binding or connecting.
+ *
+ * Once a socket has been closed, it is not available for further networking
+ * use (i.e. can't be reconnected or rebound). A new socket needs to be
+ * created.
+ * http://docs.oracle.com/javase/6/docs/api/java/net/Socket.html#close%28%29
+ *
+ * @severity error
+ */
+
+Socket_ReuseSocket(Socket sock) {
+	creation event close before(Socket sock) :
+		call(* Socket+.close(..)) && target(sock) {}
+
+	event bind before(Socket sock) :
+		call(* Socket+.bind(..)) && target(sock) {}
+
+	event connect before(Socket sock) :
+		call(* Socket+.connect(..)) && target(sock) {}
+
+	ere : close (bind | connect)+
+
+	@match {
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "Once a socket has been closed, it is not available for further networking use; a new socket needs to be created.");
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/Socket_SetTimeoutBeforeBlockingInput.mop
+++ b/scripts/javamop-agent-bundle/props/Socket_SetTimeoutBeforeBlockingInput.mop
@@ -1,0 +1,57 @@
+package mop;
+
+import java.net.*;
+import java.io.InputStream;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if the timeout option is set after the blocking operation starts.
+ *
+ * The timeout option must be enabled prior to entering the blocking operation
+ * to have effect.
+ * http://docs.oracle.com/javase/6/docs/api/java/net/Socket.html#setSoTimeout%28int%29
+ *
+ * This property ensures that the timeout option is enabled prior to entering
+ * the read operation, which can block, on the corresponding input stream. The
+ * write operation on the corresponding output stream is checked by the
+ * companion property of this one.
+ *
+ * @severity warning
+ */
+Socket_SetTimeoutBeforeBlockingInput(Socket sock, InputStream input) {
+	creation event getinput after(Socket sock) returning(InputStream input) :
+		call(InputStream Socket+.getInputStream()) && target(sock) {}
+
+	event enter before(InputStream input) :
+		call(* InputStream+.read(..)) && target(input) {}
+
+	event leave after(InputStream input) :
+		call(* InputStream+.read(..)) && target(input) {}
+
+	event set before(Socket sock, int timeout) :
+		call(* Socket+.setSoTimeout(int)) && target(sock) && args(timeout)
+		&& condition(timeout != 0) {}
+
+	fsm :
+		start [
+			getinput -> unblocked
+		]
+		unblocked [
+			getinput -> unblocked
+			set -> unblocked
+			enter -> blocked
+		]
+		blocked [
+			getinput -> blocked
+			leave -> unblocked
+		]
+
+	@fail {
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "Socket.setSoTimeout() should be set prior to entering the blocking operation.");
+
+		__RESET;
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/Socket_SetTimeoutBeforeBlockingOutput.mop
+++ b/scripts/javamop-agent-bundle/props/Socket_SetTimeoutBeforeBlockingOutput.mop
@@ -1,0 +1,57 @@
+package mop;
+
+import java.net.*;
+import java.io.OutputStream;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if the timeout option is set after the blocking operation starts.
+ *
+ * The timeout option must be enabled prior to entering the blocking operation
+ * to have effect.
+ * http://docs.oracle.com/javase/6/docs/api/java/net/Socket.html#setSoTimeout%28int%29
+ *
+ * This property ensures that the timeout option is enabled prior to entering
+ * the write operation, which can block, on the corresponding output stream.
+ * The read operation on the corresponding input stream is checked by the
+ * companion property of this one.
+ *
+ * @severity warning
+ */
+Socket_SetTimeoutBeforeBlockingOutput(Socket sock, OutputStream output) {
+	creation event getoutput after(Socket sock) returning(OutputStream output) :
+		call(OutputStream Socket+.getOutputStream()) && target(sock) {}
+
+	event enter before(OutputStream output) :
+		call(* OutputStream+.write(..)) && target(output) {}
+
+	event leave after(OutputStream output) :
+		call(* OutputStream+.write(..)) && target(output) {}
+
+	event set before(Socket sock, int timeout) :
+		call(* Socket+.setSoTimeout(int)) && target(sock) && args(timeout)
+		&& condition(timeout != 0) {}
+
+	fsm :
+		start [
+			getoutput -> unblocked
+		]
+		unblocked [
+			getoutput -> unblocked
+			set -> unblocked
+			enter -> blocked
+		]
+		blocked [
+			getoutput -> blocked
+			leave -> unblocked
+		]
+
+	@fail {
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "Socket.setSoTimeout() should be set prior to entering the blocking operation.");
+
+		__RESET;
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/Socket_Timeout.mop
+++ b/scripts/javamop-agent-bundle/props/Socket_Timeout.mop
@@ -1,0 +1,26 @@
+package mop;
+
+import java.net.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if an invalid timeout value is set to a Socket object.
+ *
+ * The timeout value must be > 0.
+ * http://docs.oracle.com/javase/6/docs/api/java/net/Socket.html#setSoTimeout%28int%29
+ *
+ * @severity error
+ */
+Socket_Timeout() {
+	event set before(int timeout) :
+		call(* Socket+.setSoTimeout(int)) && args(timeout)
+	{
+		if (timeout > 0)
+			return;
+
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "An invalid timeout value " + timeout + " was set to a Socket object.");
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/Socket_TrafficClass.mop
+++ b/scripts/javamop-agent-bundle/props/Socket_TrafficClass.mop
@@ -1,0 +1,54 @@
+package mop;
+
+import java.net.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if Socket.setTrafficClass() is called with an invalid traffic class
+ * value.
+ *
+ * The traffic class value, the only parameter of
+ * Socket.setTrafficClass(), must be between 0 and 255 inclusive.
+ * http://docs.oracle.com/javase/6/docs/api/java/net/Socket.html#setTrafficClass%28int%29
+ *
+ * According to the reference, when IPv4 is used, the last low order bit is
+ * always ignored and setting bits in the precedence field may result in a
+ * SocketException indicating that the operation is not permitted. To inform
+ * the user that some bits are ignored and may cause an error, this property
+ * warns if the last low bit or the precedence field is set.
+ *
+ * @severity error
+ */
+
+Socket_TrafficClass() {
+	event settc before(Socket socket, int tc) :
+		call(void Socket.setTrafficClass(int)) && target(socket) && args(tc)
+	{
+		boolean outofrange = !(0 <= tc && tc <= 255);
+		boolean mbz = false;
+		boolean precedence = false;
+
+		InetAddress addr = socket.getLocalAddress();
+		if (addr instanceof Inet4Address) {
+			mbz = (tc & 1) != 0 ? true : false;
+			precedence = (tc >> (4 + 1)) != 0;
+		}
+
+		if (outofrange || mbz || precedence) {
+			RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+			if (outofrange) {
+				RVMLogging.out.println(Level.CRITICAL, "The traffic class value " + tc + " is out of range; [0 ~ 255].");
+			}
+			else {
+				if (mbz) {
+					RVMLogging.out.println(Level.CRITICAL, "The traffic class value sets 1 to MBZ.");
+				}
+				if (precedence) {
+					RVMLogging.out.println(Level.CRITICAL, "The traffic class value sets non-zero precedence.");
+				}
+			}
+		}
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/SortedSet_Comparable.mop
+++ b/scripts/javamop-agent-bundle/props/SortedSet_Comparable.mop
@@ -1,0 +1,54 @@
+package mop;
+
+import java.util.*;
+import java.lang.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if a non-comparable element is about to be inserted into SortedSet.
+ *
+ * All elements inserted into a sorted set must implement the Comparable
+ * interface (or be accepted by the specified comparator). Furthermore, all
+ * such elements must be mutually comparable: e1.compareTo(e2) (or
+ * comparator.compare(e1, e2)) must not throw a ClassCastException for any
+ * elements e1 and e2 in the sorted set.
+ * http://docs.oracle.com/javase/6/docs/api/java/util/SortedSet.html
+ *
+ * This property verifies that each element implements the Comparable
+ * interface, but does not verify if all elements are mutually comparable
+ * because of performance degradation. This property does not check whether or
+ * not the specified comparator accepts the newly inserted element, because
+ * the comparator's compare() method requires two elements for comparison and
+ * it is unnatural to pick an arbitrary element or compare every existing
+ * element. As a result, it may have a false alarm even when an element is
+ * good to be accepted.
+ *
+ * @severity error
+ */
+
+SortedSet_Comparable() {
+	event add before(Object e) :
+		(
+			call(* Collection+.add*(..)) ||
+			call(* Queue+.offer*(..))
+		) && target(SortedSet) && args(e) {
+		if (!(e instanceof Comparable)) {
+			RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+			RVMLogging.out.println(Level.CRITICAL, "A non-comparable object is being inserted into a SortedSet object.");
+		}
+	}
+
+	event addall before(Collection c) :
+		call(* Collection+.addAll(Collection)) &&
+		target(SortedSet) && args(c) {
+		for (Object elem : c) {
+			if (!(elem instanceof Comparable)) {
+				RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+				RVMLogging.out.println(Level.CRITICAL, "A non-comparable object is being inserted into a SortedSet object.");
+			}
+		}
+	}
+}
+
+

--- a/scripts/javamop-agent-bundle/props/StreamTokenizer_AccessInvalidField.mop
+++ b/scripts/javamop-agent-bundle/props/StreamTokenizer_AccessInvalidField.mop
@@ -1,0 +1,74 @@
+package mop;
+
+import java.io.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Prevents access to invalidated fields of StreamTokenizer.
+ *
+ * nextToken() parses the next token from the input stream, and returns the
+ * type of the token: TT_EOF, TT_EOL (the end of line), TT_NUMBER or TT_WORD.
+ * The actual value of the token is stored at sval (or nval) only when the type
+ * is TT_WORD (or TT_NUMBER).
+ * http://download.oracle.com/javase/6/docs/api/java/io/StreamTokenizer.html#nextToken%28%29
+ *
+ * Reading sval for a TT_NUMBER typed token yields an old junk value. This
+ * specification prevents this incorrect field access.
+ *
+ * @severity warning
+ */
+
+StreamTokenizer_AccessInvalidField(StreamTokenizer s) {
+	event nexttoken_word after(StreamTokenizer s) returning(int t) :
+		call(* StreamTokenizer+.nextToken(..)) && target(s) &&
+		condition(t == StreamTokenizer.TT_WORD) {}
+
+	event nexttoken_num after(StreamTokenizer s) returning(int t) :
+		call(* StreamTokenizer+.nextToken(..)) && target(s) &&
+		condition(t == StreamTokenizer.TT_NUMBER) {}
+
+	event nexttoken_eol after(StreamTokenizer s) returning(int t) :
+		call(* StreamTokenizer+.nextToken(..)) && target(s) &&
+		condition(t == StreamTokenizer.TT_EOL) {}
+
+	event nexttoken_eof after(StreamTokenizer s) returning(int t) :
+		call(* StreamTokenizer+.nextToken(..)) && target(s) &&
+		condition(t == StreamTokenizer.TT_EOF) {}
+
+	event sval before(StreamTokenizer s) :
+		get(* StreamTokenizer.sval) && target(s) {}
+
+	event nval before(StreamTokenizer s) :
+		get(* StreamTokenizer.nval) && target(s) {}
+
+	fsm :
+		valid [
+			nexttoken_word -> read_word
+			nexttoken_num -> read_num
+			nexttoken_eol -> valid
+			nexttoken_eof -> done
+		]
+		read_word [
+			sval -> read_word
+			nexttoken_word -> read_word
+			nexttoken_num -> read_num
+			nexttoken_eol -> valid
+			nexttoken_eof -> done
+		]
+		read_num [
+			nval -> read_num
+			nexttoken_word -> read_word
+			nexttoken_num -> read_num
+			nexttoken_eol -> valid
+			nexttoken_eof -> done
+		]
+		done [
+		]
+
+	@fail {
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "The caller attempted to read an invalidated value. " + __LOC);
+		__RESET;
+	}
+}

--- a/scripts/javamop-agent-bundle/props/StrictMath_ContendedRandom.mop
+++ b/scripts/javamop-agent-bundle/props/StrictMath_ContendedRandom.mop
@@ -1,0 +1,36 @@
+package mop;
+
+import java.lang.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * suggests if a StrictMath.random() is used by multiple threads.
+ *
+ * According to the manual, StrictMath.random() is thread-safe.  
+ * However, when multiple threads need to generate random numbers,
+ * it may reduce contention for each thread to have its own pseudorandom-number generator.
+ * Random.nextDouble() is recommended in such a case.
+ * http://docs.oracle.com/javase/6/docs/api/java/lang/StrictMath.html#random%28%29
+ * 
+ * @severity suggestion
+ */
+ 
+StrictMath_ContendedRandom() {
+	Thread th = null;
+
+	event onethread_use before(Thread t) :
+		call(* StrictMath.random(..)) && thread(t) && condition(this.th == null || this.th == t){
+			this.th = t;
+		}
+	event otherthread_use before(Thread t) :
+		call(* StrictMath.random(..)) && thread(t) && condition(this.th != t){
+		}
+
+	ere : onethread_use*
+
+	@fail {
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "StrictMath.random() is used by multiple threads. If there is contention, we recommend you to use Random.nextDouble().");
+	}
+}

--- a/scripts/javamop-agent-bundle/props/StringBuilder_ThreadSafe.mop
+++ b/scripts/javamop-agent-bundle/props/StringBuilder_ThreadSafe.mop
@@ -1,0 +1,46 @@
+package mop;
+
+import java.io.*;
+import java.lang.*;
+import java.util.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if two threads attempt to use the same StringBuilder object.
+ *
+ * According to the manual, this class is not synchronized.
+ * http://docs.oracle.com/javase/6/docs/api/java/lang/StringBuilder.html
+ * User should use StringBuffer in this case.
+ *
+ * @severity warning
+ */
+
+StringBuilder_ThreadSafe(StringBuilder b){
+    Thread owner = null;
+
+    event safe_oper before(StringBuilder b, Thread t) : 
+        call(* StringBuilder.*(..)) && target(b) && thread(t)
+        && condition(this.owner == null || this.owner == t) {
+            this.owner = t;
+        }
+    
+    event unsafe_oper before(StringBuilder b, Thread t) : 
+        call(* StringBuilder.*(..)) && target(b) && thread(t)
+        && condition(this.owner != null && this.owner != t) {}
+
+	ere: safe_oper*
+
+	@fail {
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "More than two threads attempted to use a StringBuilder instance, which may lead to a race condition. Use StringBuffer instead.");
+		__RESET;
+	}
+}
+		
+
+
+
+
+
+

--- a/scripts/javamop-agent-bundle/props/StringTokenizer_HasMoreElements.mop
+++ b/scripts/javamop-agent-bundle/props/StringTokenizer_HasMoreElements.mop
@@ -1,0 +1,48 @@
+package mop;
+
+import java.util.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if nextToken()/nextElement() is invoked when
+ * hasMoreTokens()/hasMoreElements() is not invoked or returns false.
+ *
+ * This property requires that hasMoreTokens()/hasMoreElements() be called
+ * before nextToken()/nextElement() and that hasMoreTokens()/hasMoreElements()
+ * return true.
+ *
+ * This property may raise a false positive because one may safely call
+ * nextToken()/nextElement() multiple times after retrieving the actual number
+ * of elements.
+ *
+ * @severity warning
+ */
+
+StringTokenizer_HasMoreElements(StringTokenizer i) {
+	event hasnexttrue after(StringTokenizer i) returning(boolean b) :
+		(
+			call(boolean StringTokenizer.hasMoreTokens()) ||
+			call(boolean StringTokenizer.hasMoreElements())
+		) && target(i) && condition(b) {}
+
+	event hasnextfalse after(StringTokenizer i) returning(boolean b) :
+		(
+			call(boolean StringTokenizer.hasMoreTokens()) ||
+			call(boolean StringTokenizer.hasMoreElements())
+		) && target(i) && condition(!b) {}
+
+	event next before(StringTokenizer i) :
+		(
+			call(* StringTokenizer.nextToken()) ||
+			call(* StringTokenizer.nextElement())
+		) && target(i) {}
+
+	ltl: [](next => (*) hasnexttrue)
+
+	@violation {
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "StringTokenizer.hasMoreTokens()/hasMoreElements() did not return false before calling nextToken()/nextElement().");
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/String_UseStringBuilder.mop
+++ b/scripts/javamop-agent-bundle/props/String_UseStringBuilder.mop
@@ -1,0 +1,26 @@
+package mop;
+
+import java.io.*;
+import java.lang.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Suggests if the constructor of String is used.
+ *
+ * According to the manual, using the constructor is likely to be slower. 
+ * Rather, one should use toString() on the StringBuilder.
+ * http://docs.oracle.com/javase/6/docs/api/java/lang/String.html#String%28java.lang.StringBuilder%29
+ *
+ * @severity suggestion
+ */
+ 
+String_UseStringBuilder() {
+    event constructor_create after() returning(String b): 
+        call(String.new(StringBuilder)) {
+            RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+            RVMLogging.out.println(Level.CRITICAL, "Using the constructor String(StringBuilder builder) is inefficient. Use toString() method on the StringBuilder.");
+        }
+    
+}
+

--- a/scripts/javamop-agent-bundle/props/System_NullArrayCopy.mop
+++ b/scripts/javamop-agent-bundle/props/System_NullArrayCopy.mop
@@ -1,0 +1,24 @@
+package mop;
+
+import java.io.*;
+import java.lang.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if src or dest is null.
+ *
+ * According to the manual, src and dest should not be null. 
+ * http://docs.oracle.com/javase/6/docs/api/java/lang/System.html#arraycopy%28java.lang.Object,%20int,%20java.lang.Object,%20int,%20int%29
+ *
+ * @severity error
+ */
+ 
+System_NullArrayCopy() {
+	event null_arraycopy before(Object src, int srcPos, Object dest, int destPos, int length): 
+		call(* System.arraycopy(Object, int, Object, int, int)) && args(src, srcPos, dest, destPos, length) && condition(src == null || dest == null) {
+			RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+			RVMLogging.out.println(Level.CRITICAL, "src or dest should not be null.");
+		}
+}
+

--- a/scripts/javamop-agent-bundle/props/System_WrongKeyOrValue.mop
+++ b/scripts/javamop-agent-bundle/props/System_WrongKeyOrValue.mop
@@ -1,0 +1,49 @@
+package mop;
+
+import java.io.*;
+import java.lang.*;
+import java.util.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if null key or value is inserted, or non-String key or value is used.
+ *
+ * According to the manual, the returned map from getenv() does not permit null keys or values.
+ * Also, attempting to query the presence of a key or value which is not of type String is not allowed.   
+ * http://docs.oracle.com/javase/6/docs/api/java/lang/System.html#getenv%28%29
+ *
+ * @severity error
+ */
+
+System_WrongKeyOrValue(Map map){
+
+	creation event createMap after() returning(Map map) : 
+        call(Map System.getenv()) {}
+              
+	event nullPut before(Map map, Object key, Object value) : 
+        call(* Map.put(..)) && args(key, value) && target(map) && condition(key == null || value == null){}
+
+	event nullPut before(Map map, Map map2) : 
+        call(* Map.putAll(Map)) && args(map2) && target(map) && condition(map2.containsKey(null) || map2.containsValue(null)){}
+
+	event nullQuery before(Map map, Object o) : 
+	    (call(* Map.containsKey(..)) || call(* Map.containsValue(..)) || call(* Map.get(..)) || call(* Map.remove(..))) && target(map) && args(o) && condition(o == null){}
+
+	event notStringQuery before(Map map, Object o) : 
+	    (call(* Map.containsKey(..)) || call(* Map.containsValue(..)) || call(* Map.get(..)) || call(* Map.remove(..))) && target(map) && args(o) && condition(!(o instanceof String)){}
+
+    ere : createMap (nullPut | nullQuery | notStringQuery)+ 
+
+	@match{
+           RVMLogging.out.println(Level.WARNING, __DEFAULT_MESSAGE);
+           RVMLogging.out.println(Level.WARNING, "null key or value is not permitted in the map from System.getenv(). Also key or value which is not of type String is not allowed.");
+	}
+}
+		
+
+
+
+
+
+

--- a/scripts/javamop-agent-bundle/props/Thread_SetDaemonBeforeStart.mop
+++ b/scripts/javamop-agent-bundle/props/Thread_SetDaemonBeforeStart.mop
@@ -1,0 +1,40 @@
+package mop;
+
+import java.io.*;
+import java.lang.*;
+import java.util.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if setDaemon is called after starting the thread.
+ *
+ * According to the manual, it should be called before starting
+ * http://docs.oracle.com/javase/6/docs/api/java/lang/Thread.html#setDaemon%28boolean%29
+ *
+ * @severity error
+ */
+
+Thread_SetDaemonBeforeStart(Thread t){
+	event start before(Thread t) : 
+        startThread() && thread(t) {
+        }
+
+	event setDaemon before(Thread t) : 
+        call(* Thread+.setDaemon(..)) && target(t) {
+        }
+
+    ere : setDaemon* start 
+
+	@fail{
+           RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+           RVMLogging.out.println(Level.CRITICAL, "setDaemon should not be set after the thread started");
+	}
+}
+		
+
+
+
+
+
+

--- a/scripts/javamop-agent-bundle/props/Thread_StartOnce.mop
+++ b/scripts/javamop-agent-bundle/props/Thread_StartOnce.mop
@@ -1,0 +1,35 @@
+package mop;
+
+import java.io.*;
+import java.lang.*;
+import java.util.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if a thread is started more than once.
+ *
+ * According to the manual, it is never legal to start a thread more than once.
+ * http://docs.oracle.com/javase/6/docs/api/java/lang/Thread.html#start%28%29
+ *
+ * @severity error
+ */
+
+Thread_StartOnce(Thread t){
+	event start before(Thread t) : 
+        call(* Thread+.start()) && target(t) {}
+
+    ere : start start+ 
+
+	@match{
+           RVMLogging.out.println(Level.WARNING, __DEFAULT_MESSAGE);
+           RVMLogging.out.println(Level.WARNING, "Thread should not be started more than once.");
+	}
+}
+		
+
+
+
+
+
+

--- a/scripts/javamop-agent-bundle/props/Throwable_InitCauseOnce.mop
+++ b/scripts/javamop-agent-bundle/props/Throwable_InitCauseOnce.mop
@@ -1,0 +1,41 @@
+package mop;
+
+import java.io.*;
+import java.lang.*;
+import java.util.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if a Throwable object initializes its cause more than once.
+ *
+ * According to the manual, initCause can be called at most once.
+ * http://docs.oracle.com/javase/6/docs/api/java/lang/Throwable.html#initCause%28java.lang.Throwable%29
+ *
+ * @severity error
+ */
+
+Throwable_InitCauseOnce(Throwable t){
+	event createWithoutThrowable after() returning(Throwable t) :
+		call(Throwable+.new()) || call(Throwable+.new(String)) {}
+
+	event createWithThrowable after() returning(Throwable t) :
+		call(Throwable+.new(String, Throwable)) || call(Throwable+.new(Throwable)) {}
+
+	event initCause before(Throwable t) : 
+        call(* Throwable+.initCause(..)) && target(t) {}
+
+    ere : (createWithoutThrowable initCause initCause+) | (createWithThrowable initCause+)  
+
+	@match{
+           RVMLogging.out.println(Level.WARNING, __DEFAULT_MESSAGE);
+           RVMLogging.out.println(Level.WARNING, "initCause should not be called more than once.");
+	}
+}
+		
+
+
+
+
+
+

--- a/scripts/javamop-agent-bundle/props/TreeMap_Comparable.mop
+++ b/scripts/javamop-agent-bundle/props/TreeMap_Comparable.mop
@@ -1,0 +1,51 @@
+package mop;
+
+import java.util.*;
+import java.lang.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if a non-comparable key is about to be inserted into TreeMap.
+ *
+ * When a TreeMap object is created without a specific comparator, all keys
+ * inserted into the map must implement the Comparable interface.
+ * http://docs.oracle.com/javase/6/docs/api/java/util/TreeMap.html#TreeMap%28%29
+ *
+ * This property verifies that each key implements the Comparable interface,
+ * but does not verify if all keys are mutually comparable because of
+ * performance degradation.
+ *
+ * @severity error
+ */
+
+TreeMap_Comparable() {
+	private void validate(Object elem, String msg) {
+		if (!(elem instanceof Comparable)) {
+			RVMLogging.out.println(Level.CRITICAL, msg);
+			RVMLogging.out.println(Level.CRITICAL, "A non-comparable object is being inserted into a TreeMap object.");
+		}
+	}
+
+	private void validateAll(Map src, String msg) {
+		for (Map.Entry entry : (Collection<Map.Entry>)src.entrySet()) {
+			validate(entry.getKey(), msg);
+		}
+	}
+
+	event create before(Map src) :
+		call(TreeMap.new(Map)) && args(src) {
+		validateAll(src, __DEFAULT_MESSAGE);
+	}
+
+	event put before(Object key) :
+		call(* Map+.put(Object, Object)) && args(key, ..) && target(TreeMap){
+		validate(key, __DEFAULT_MESSAGE);
+	}
+
+	event putall before(Map src) :
+		call(* Map+.putAll(Map)) && args(src) &&target(TreeMap){
+		validateAll(src, __DEFAULT_MESSAGE);
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/TreeSet_Comparable.mop
+++ b/scripts/javamop-agent-bundle/props/TreeSet_Comparable.mop
@@ -1,0 +1,45 @@
+package mop;
+
+import java.util.*;
+import java.lang.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if a non-comparable element is about to be inserted into TreeSet.
+ *
+ * When a TreeSet object is created without a specific comparator, all
+ * elements inserted into the map must implement the Comparable interface.
+ * http://docs.oracle.com/javase/6/docs/api/java/util/TreeSet.html#TreeSet%28%29
+ *
+ * This property verifies that each element implements the Comparable
+ * interface, but does not verify if all elements are mutually comparable
+ * because of performance degradation.
+ *
+ * @severity error
+ */
+
+TreeSet_Comparable() {
+	event add before(Object e) :
+		(
+			call(* Collection+.add*(..))
+		) && target(TreeSet) && args(e) {
+		if (!(e instanceof Comparable)) {
+			RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+			RVMLogging.out.println(Level.CRITICAL, "A non-comparable object is being inserted into a TreeSet object.");
+		}
+	}
+
+	event addall before(Collection c) :
+		call(* Collection+.addAll(Collection)) &&
+		target(TreeSet) && args(c) {
+		for (Object elem : c) {
+			if (!(elem instanceof Comparable)) {
+				RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+				RVMLogging.out.println(Level.CRITICAL, "A non-comparable object is being inserted into a TreeSet object.");
+			}
+		}
+	}
+}
+
+

--- a/scripts/javamop-agent-bundle/props/URLConnection_Connect.mop
+++ b/scripts/javamop-agent-bundle/props/URLConnection_Connect.mop
@@ -1,0 +1,72 @@
+package mop;
+
+import java.net.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if URLConnection.connect() is called when the connection has already
+ * been opened.
+ *
+ * If the connect method is called when the connection has already been opened
+ * (indicated by the connected field having the value true), the call is
+ * ignored.
+ * http://docs.oracle.com/javase/6/docs/api/java/net/URLConnection.html#connect%28%29
+ *
+ * Besides the connect() method, there are many other ways for a URLConnection
+ * object to be connected. It seems that the rule of thumb is any method that
+ * requires server's information, such as response headers and contents,
+ * causes th URLConnection object to be connected. Such methods include, but
+ * not limited to, the following methods:
+ *  URLConnection.connect()
+ *  URLConnection.getContent()
+ *  URLConnection.getContentEncoding()
+ *  URLConnection.getContentLength()
+ *  URLConnection.getContentType()
+ *  URLConnection.getDate()
+ *  URLConnection.getExpiration()
+ *  URLConnection.getHeaderField()
+ *  URLConnection.getHeaderFieldInt()
+ *  URLConnection.getHeaderFields()
+ *  URLConnection.getInputStream()
+ *  URLConnection.getLastModified()
+ *  URLConnection.getOutputStream()
+ *
+ * It should be noted that the above list is not comprehensive since a
+ * subclass may define its own connection-triggering method. For example, the
+ * HttpURLConnection class in the sun.net.www.protocol.http package, a
+ * subclass of java.net.HttpURLConnection, defines one such method,
+ * doTunneling().
+ *
+ * This property may give false warnings.
+ *
+ * @severity warning
+ */
+URLConnection_Connect(URLConnection c) {
+	event explicit before(URLConnection c) :
+		call(* URLConnection+.connect(..)) && target(c) {}
+
+	event implicit before(URLConnection c) :
+		(
+			call(* URLConnection+.getContent(..)) ||
+			call(* URLConnection+.getContentEncoding(..)) ||
+			call(* URLConnection+.getContentLength(..)) ||
+			call(* URLConnection+.getContentType(..)) ||
+			call(* URLConnection+.getDate(..)) ||
+			call(* URLConnection+.getExpiration(..)) ||
+			call(* URLConnection+.getHeaderField(..)) ||
+			call(* URLConnection+.getHeaderFieldInt(..)) ||
+			call(* URLConnection+.getHeaderFields(..)) ||
+			call(* URLConnection+.getInputStream(..)) ||
+			call(* URLConnection+.getLastModified(..)) ||
+			call(* URLConnection+.getOutputStream(..))
+		) && target(c) {}
+
+	ere : (explicit | implicit) explicit+
+
+	@match {
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "URLConnection.connect() has been called multiple twice.");
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/URLConnection_OverrideGetPermission.mop
+++ b/scripts/javamop-agent-bundle/props/URLConnection_OverrideGetPermission.mop
@@ -1,0 +1,53 @@
+package mop;
+
+import java.net.*;
+import java.lang.reflect.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if a subclass of URLConnection does not override getPermission().
+ *
+ * Subclasses of URLConnection should override the default implementation of
+ * getPermission().
+ * http://docs.oracle.com/javase/6/docs/api/java/net/URLConnection.html#getPermission%28%29
+ *
+ * This property warns if a class or one of its superclass does not override
+ * getPermission().
+ *
+ * @severity error
+ */
+
+URLConnection_OverrideGetPermission() {
+	event staticinit after() : staticinitialization(URLConnection+) {
+		org.aspectj.lang.Signature initsig = __STATICSIG;
+		Class klass = initsig.getDeclaringType();		
+
+		Method overriden = null;
+		while (klass != null && !klass.getName().equals("java.net.URLConnection")) {
+			try {
+				for (Method m : klass.getDeclaredMethods()) {
+					if (!m.getName().equals("getPermission"))
+						continue;
+					if (m.getParameterTypes().length != 0)
+						continue;
+
+					overriden = m;
+					break;
+				}
+				if (overriden != null)
+					break;
+			}
+			catch (SecurityException e) {
+			}
+
+			klass = klass.getSuperclass();
+		}
+
+		if (overriden == null) {
+			RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+			RVMLogging.out.println(Level.CRITICAL, "A URLConnection class should override the getPermission() method.");
+		}
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/URLConnection_SetBeforeConnect.mop
+++ b/scripts/javamop-agent-bundle/props/URLConnection_SetBeforeConnect.mop
@@ -1,0 +1,72 @@
+package mop;
+
+import java.net.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if options are specified after URLConnection is connected.
+ *
+ * After being created, and before being connected, various options can be
+ * specified (e.g., doInput and UseCaches). After connecting, it is an error
+ * to try to set them.
+ * http://docs.oracle.com/javase/6/docs/api/java/net/URLConnection.html#connect%28%29
+ *
+ * Besides the connect() method, there are many other ways for a URLConnection
+ * object to be connected. It seems that the rule of thumb is any method that
+ * requires server's information, such as response headers and contents,
+ * causes th URLConnection object to be connected. Such methods include, but
+ * not limited to, the following methods:
+ *  URLConnection.connect()
+ *  URLConnection.getContent()
+ *  URLConnection.getContentEncoding()
+ *  URLConnection.getContentLength()
+ *  URLConnection.getContentType()
+ *  URLConnection.getDate()
+ *  URLConnection.getExpiration()
+ *  URLConnection.getHeaderField()
+ *  URLConnection.getHeaderFieldInt()
+ *  URLConnection.getHeaderFields()
+ *  URLConnection.getInputStream()
+ *  URLConnection.getLastModified()
+ *  URLConnection.getOutputStream()
+ *
+ * It should be noted that the above list is not comprehensive since a
+ * subclass may define its own connection-triggering method. For example, the
+ * HttpURLConnection class in the sun.net.www.protocol.http package, a
+ * subclass of java.net.HttpURLConnection, defines one such method,
+ * doTunneling().
+ *
+ * This property may give false warnings.
+ *
+ * @severity error
+ */
+URLConnection_SetBeforeConnect(URLConnection c) {
+	event set before(URLConnection c) :
+		call(* URLConnection+.set*(..)) && target(c) {}
+
+	event connect before(URLConnection c) :
+		(
+			call(* URLConnection+.connect(..)) ||
+			call(* URLConnection+.getContent(..)) ||
+			call(* URLConnection+.getContentEncoding(..)) ||
+			call(* URLConnection+.getContentLength(..)) ||
+			call(* URLConnection+.getContentType(..)) ||
+			call(* URLConnection+.getDate(..)) ||
+			call(* URLConnection+.getExpiration(..)) ||
+			call(* URLConnection+.getHeaderField(..)) ||
+			call(* URLConnection+.getHeaderFieldInt(..)) ||
+			call(* URLConnection+.getHeaderFields(..)) ||
+			call(* URLConnection+.getInputStream(..)) ||
+			call(* URLConnection+.getLastModified(..)) ||
+			call(* URLConnection+.getOutputStream(..))
+		) && target(c) {}
+
+	ere : set* connect*
+
+	@fail {
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "Options were specified after the connection was made.");
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/URLDecoder_DecodeUTF8.mop
+++ b/scripts/javamop-agent-bundle/props/URLDecoder_DecodeUTF8.mop
@@ -1,0 +1,27 @@
+package mop;
+
+import java.net.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if URLDecoder.decode() is used for non-UTF-8 encoding.
+ *
+ * The World Wide Web Consortium Recommendation states that UTF-8 should be
+ * used. Not doing so may introduce incompatibilites.
+ * http://docs.oracle.com/javase/6/docs/api/java/net/URLDecoder.html#decode%28java.lang.String,%20java.lang.String%29
+ *
+ * @severity warning
+ */
+URLDecoder_DecodeUTF8() {
+	event decode before(String enc) :
+		call(* URLDecoder.decode(String, String)) && args(*, enc)
+	{
+		if (enc.equalsIgnoreCase("utf-8") || enc.equalsIgnoreCase("utf8"))
+			return;
+
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "The used encoding '" + enc + "' may introduce incompatibilites.");
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/URLEncoder_EncodeUTF8.mop
+++ b/scripts/javamop-agent-bundle/props/URLEncoder_EncodeUTF8.mop
@@ -1,0 +1,27 @@
+package mop;
+
+import java.net.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if URLEncoder.encode() is used for non-UTF-8 encoding.
+ *
+ * The World Wide Web Consortium Recommendation states that UTF-8 should be
+ * used. Not doing so may introduce incompatibilites.
+ * http://docs.oracle.com/javase/6/docs/api/java/net/URLEncoder.html#encode%28java.lang.String,%20java.lang.String%29
+ *
+ * @severity warning
+ */
+URLEncoder_EncodeUTF8() {
+	event encode before(String enc) :
+		call(* URLEncoder.encode(String, String)) && args(*, enc)
+	{
+		if (enc.equalsIgnoreCase("utf-8") || enc.equalsIgnoreCase("utf8"))
+			return;
+
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "The used encoding '" + enc + "' may introduce incompatibilites.");
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/URL_SetURLStreamHandlerFactory.mop
+++ b/scripts/javamop-agent-bundle/props/URL_SetURLStreamHandlerFactory.mop
@@ -1,0 +1,26 @@
+package mop;
+
+import java.net.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if URL.setURLStreamHandlerFactory() is called multiple times.
+ *
+ * This method can be called at most once in a given Java Virtual Machine.
+ * http://docs.oracle.com/javase/6/docs/api/java/net/URL.html#setURLStreamHandlerFactory%28java.net.URLStreamHandlerFactory%29
+ *
+ * @severity error
+ */
+URL_SetURLStreamHandlerFactory() {
+	event set before() :
+		call(* URL.setURLStreamHandlerFactory(..)) {}
+
+	ere : set set+
+
+	@match {
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "URL.setURLStreamHandlerFactory() can be called at most once in a given Java Virtual Machine.");
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/Vector_InsertIndex.mop
+++ b/scripts/javamop-agent-bundle/props/Vector_InsertIndex.mop
@@ -1,0 +1,26 @@
+package mop;
+
+import java.util.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns if the index passed to insertElementAt() is invalid.
+ *
+ * The index passed to insertElementAt() must be a value greater than or equal
+ * to 0 and less than or equal to the current size of the vector.
+ * http://docs.oracle.com/javase/6/docs/api/java/util/Vector.html#insertElementAt%28E,%20int%29
+ *
+ * @severity error
+ */
+
+Vector_InsertIndex() {
+	event insert before(Vector v, int index) :
+		call(* Vector+.insertElementAt(Object, int)) && target(v) && args(.., index) {
+		if (!(0 <= index && index <= v.size())) {
+			RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+			RVMLogging.out.println(Level.CRITICAL, "The index passed to insertElementAt() is invalid.");
+		}
+	}
+}
+

--- a/scripts/javamop-agent-bundle/props/Writer_ManipulateAfterClose.mop
+++ b/scripts/javamop-agent-bundle/props/Writer_ManipulateAfterClose.mop
@@ -1,0 +1,39 @@
+package mop;
+
+import java.io.*;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging;
+import com.runtimeverification.rvmonitor.java.rt.RVMLogging.Level;
+
+/**
+ * Warns write(), or flush() after close().
+ *
+ * According to the Writer.close() documentation, further write() or flush()
+ * invocations will cause an IOException to be thrown.
+ * http://download.oracle.com/javase/6/docs/api/java/io/Writer.html#close%28%29
+ *
+ * Other subclasses of Writer are deemed to be similar, except CharArrayWriter
+ * and StringWriter.
+ * http://docs.oracle.com/javase/6/docs/api/java/io/CharArrayWriter.html#close%28%29
+ * http://docs.oracle.com/javase/6/docs/api/java/io/StringWriter.html#close%28%29
+ *
+ * @severity error
+ */
+
+Writer_ManipulateAfterClose(Writer w) {
+	event manipulate before(Writer w) :
+		(
+			call(* Writer+.write*(..)) ||
+			call(* Writer+.flush(..))
+		) && target(w) &&
+		!target(CharArrayWriter) && !target(StringWriter) {}
+	creation event close before(Writer w) :
+		call(* Writer+.close(..)) && target(w) &&
+		!target(CharArrayWriter) && !target(StringWriter) {}
+
+	ere : close+ manipulate+
+
+	@match {
+		RVMLogging.out.println(Level.CRITICAL, __DEFAULT_MESSAGE);
+		RVMLogging.out.println(Level.CRITICAL, "write() or flush() was invoked after close().");
+	}
+}

--- a/scripts/make-and-install-agent.sh
+++ b/scripts/make-and-install-agent.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+SCRIPT_DIR=$( cd $( dirname $0 ) && pwd )
+
+cd ${SCRIPT_DIR}/javamop-agent-bundle
+
+echo "Creating agent..."
+bash make-agent.sh props agents quiet
+
+res="$?"
+
+if [ "${res}" -eq 0 ]; then
+    echo
+    echo "Installing agent..."
+    mvn install:install-file -Dfile=agents/JavaMOPAgent.jar -DgroupId="javamop-agent" -DartifactId="javamop-agent" -Dversion="1.0" -Dpackaging="jar"
+else
+    echo "Agent build was unsuccessful, exiting..."
+fi


### PR DESCRIPTION
Changes to `scripts/javamop-agent-bundle` so that the created JAR contains a file containing the list of specifications contained in the JAR. This is important so that RPP can compute the set of specs that were *not* included in a potential user-specified list of specs. This PR needs close review, since it is integral for RPP.

Note that the PR for `javamop-agent-bundle` needs to be merged before this PR should be reviewed.