### PR TITLE
Paths bugfix

### DIFF
--- a/emop-maven-plugin/src/main/java/edu/cornell/AffectedSpecsMojo.java
+++ b/emop-maven-plugin/src/main/java/edu/cornell/AffectedSpecsMojo.java
@@ -9,7 +9,11 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.PrintWriter;
 import java.net.JarURLConnection;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Enumeration;
@@ -224,16 +228,32 @@ public class AffectedSpecsMojo extends ImpactedClassMojo {
         return Writer.pathToString(getSureFireClassPath().getClassPath());
     }
 
-    private void makeSourcesFile(String sourceList, Set<String> impacted) {
+    /**
+     * Given a path to a class file, returns a path to its corresponding source file. Assumes a standard directory
+     * layout, i.e., one where the source for {@code com.abc.A} resides in {@code sourceDir/com/abc/A.java}.
+     * @param classFile the path to the class file
+     * @param classesDir the base class file directory
+     * @param sourceDir the base sources directory
+     * @return the path to the source file
+     */
+    private static Path classFileToSource(Path classFile, Path classesDir, Path sourceDir) {
+        Path parent = sourceDir.resolve(classesDir.relativize(classFile)).getParent();
+        return parent.resolve(classFile.getFileName().toString().replace(".class", ".java"));
+    }
+
+    private void makeSourcesFile(String sourceList, Set<String> impacted) throws MojoExecutionException {
         Set<String> classes = new HashSet<>();
+        Path testSourceDir = getTestSourceDirectory().toPath().toAbsolutePath();
+        Path sourceDir = Paths.get(getTestSourceDirectory().getAbsolutePath().replace(
+                "src" + File.separator + "test", "src" + File.separator + "main"));
+
         for (String klas : impacted) {
             if (klas.contains("$")) {
                 klas = klas.substring(0, klas.indexOf("$"));
             }
             klas = klas.replace(".", File.separator) + ".java";
-            File test = new File(getTestSourceDirectory().getAbsolutePath() + File.separator + klas);
-            File source = new File(test.getAbsolutePath().replace("src" + File.separator + "test",
-                    "src" + File.separator + "main"));
+            File test = testSourceDir.resolve(klas).toFile();
+            File source = sourceDir.resolve(klas).toFile();
             if (source.exists()) {
                 classes.add(source.getAbsolutePath());
             } else if (test.exists()) {
@@ -241,9 +261,40 @@ public class AffectedSpecsMojo extends ImpactedClassMojo {
             } else {
                 getLog().error("Source file not found: " + source.getAbsolutePath());
                 getLog().error("Test file not found: " + test.getAbsolutePath());
+                throw new MojoExecutionException("Couldn't find source file for impacted class");
             }
         }
-        classes.addAll(getChanged());
+
+        Path classesDir = getClassesDirectory().toPath().toAbsolutePath();
+        Path testClassesDir = getTestClassesDirectory().toPath().toAbsolutePath();
+
+        for (String klas : getChanged()) {
+            if (klas.contains("$")) {
+                klas = klas.substring(0, klas.indexOf('$')) + ".class";
+            }
+
+            try {
+                Path classFile = Paths.get(new URI(klas)).toAbsolutePath();
+                Path sourceFile = null;
+
+                if (classFile.startsWith(classesDir)) {
+                    sourceFile = classFileToSource(classFile, classesDir, sourceDir);
+                } else if (classFile.startsWith(testClassesDir)) {
+                    sourceFile = classFileToSource(classFile, testClassesDir, testSourceDir);
+                } else {
+                    throw new MojoExecutionException("Couldn't find class file for changed class");
+                }
+
+                if (sourceFile.toFile().exists()) {
+                    classes.add(sourceFile.toString());
+                } else {
+                    throw new MojoExecutionException("Couldn't find source file for changed class");
+                }
+            } catch (URISyntaxException ex) {
+                throw new MojoExecutionException("Couldn't parse URI for changed class", ex);
+            }
+        }
+
         Writer.writeToFile(classes, sourceList);
     }
 


### PR DESCRIPTION
Fixes a bug in `makeSourcesFile` where class file URLs are being written to `sources.lst` rather than source file paths.