### PR TITLE
RPS + RPP

### DIFF
--- a/emop-core/src/main/java/edu/cornell/emop/util/Util.java
+++ b/emop-core/src/main/java/edu/cornell/emop/util/Util.java
@@ -149,11 +149,15 @@ public class Util {
             writer.println("</aspects>");
             // TODO: Hard-coded for now, make optional later (-verbose -showWeaveInfo)
             writer.println("<weaver options=\"-nowarn -Xlint:ignore\">");
-            for (String packageName : includesPackageNames) {
-                writer.println("<include within=\"" + packageName + "..*\"/>");
+            if (includesPackageNames != null) {
+                for (String packageName : includesPackageNames) {
+                    writer.println("<include within=\"" + packageName + "..*\"/>");
+                }
             }
-            for (String nonAffectedClass : nonAffectedClasses) {
-                writer.println("<exclude within=\"" + nonAffectedClass + "\"/>");
+            if (nonAffectedClasses != null) {
+                for (String nonAffectedClass : nonAffectedClasses) {
+                    writer.println("<exclude within=\"" + nonAffectedClass + "\"/>");
+                }
             }
             writer.println("</weaver>");
 

--- a/emop-core/src/main/java/edu/cornell/emop/util/Util.java
+++ b/emop-core/src/main/java/edu/cornell/emop/util/Util.java
@@ -3,6 +3,7 @@ package edu.cornell.emop.util;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileFilter;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.PrintWriter;
@@ -187,5 +188,19 @@ public class Util {
             throw new RuntimeException(ex);
         }
         return newViolationCounts.getAbsolutePath();
+    }
+
+    /**
+     * Writes the provided set of specifications to the specified file, delimited by newline.
+     * @param specs set of specs to write to the file
+     * @param file the file to write to
+     * @throws FileNotFoundException when file cannot be found
+     */
+    public static void writeSpecsToFile(Set<String> specs, File file) throws FileNotFoundException {
+        try (PrintWriter writer = new PrintWriter(file)) {
+            for (String spec : specs) {
+                writer.println(spec);
+            }
+        }
     }
 }

--- a/emop-maven-plugin/src/main/java/edu/cornell/MonitorMojo.java
+++ b/emop-maven-plugin/src/main/java/edu/cornell/MonitorMojo.java
@@ -51,7 +51,7 @@ public class MonitorMojo extends AffectedSpecsMojo {
                 monitorIncludes, monitorExcludes);
         getLog().info("rps-rpp: " + rpsRpp);
         if (rpsRpp) {
-            getLog().info("In mode RPS-RPP");
+            getLog().info("In mode RPS-RPP, writing the list of affected specs to affected-specs.txt...");
             try {
                 Util.writeSpecsToFile(affectedSpecs, new File(
                         getArtifactsDir(), "affected-specs.txt"));

--- a/emop-maven-plugin/src/main/java/edu/cornell/MonitorMojo.java
+++ b/emop-maven-plugin/src/main/java/edu/cornell/MonitorMojo.java
@@ -1,6 +1,7 @@
 package edu.cornell;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -37,6 +38,9 @@ public class MonitorMojo extends AffectedSpecsMojo {
     @Parameter(property = "includeLibraries", required = false, defaultValue = "true")
     private boolean includeLibraries;
 
+    @Parameter(property = "rpsRpp", defaultValue = "false")
+    private boolean rpsRpp;
+
     public void execute() throws MojoExecutionException {
         super.execute();
         getLog().info("[eMOP] Invoking the Monitor Mojo...");
@@ -45,6 +49,17 @@ public class MonitorMojo extends AffectedSpecsMojo {
         monitorExcludes = includeNonAffected ? new HashSet<>() : getNonAffected();
         Util.generateNewMonitorFile(getArtifactsDir() + File.separator + monitorFile, affectedSpecs,
                 monitorIncludes, monitorExcludes);
+        getLog().info("rps-rpp: " + rpsRpp);
+        if (rpsRpp) {
+            getLog().info("In mode RPS-RPP");
+            try {
+                Util.writeSpecsToFile(affectedSpecs, new File(
+                        getArtifactsDir(), "affected-specs.txt"));
+            } catch (FileNotFoundException ex) {
+                throw new RuntimeException(ex);
+            }
+            System.setProperty("rpsRpp", "true");
+        }
         if (javamopAgent == null) {
             javamopAgent = getLocalRepository().getBasedir() + File.separator + "javamop-agent"
                     + File.separator + "javamop-agent"

--- a/emop-maven-plugin/src/main/java/edu/cornell/MonitorMojo.java
+++ b/emop-maven-plugin/src/main/java/edu/cornell/MonitorMojo.java
@@ -13,6 +13,9 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
 @Mojo(name = "monitor", requiresDirectInvocation = true, requiresDependencyResolution = ResolutionScope.TEST)
 public class MonitorMojo extends AffectedSpecsMojo {
 
+    protected static Set<String> monitorIncludes;
+    protected static Set<String> monitorExcludes;
+
     private String monitorFile = "new-aop-ajc.xml";
 
     /**
@@ -38,9 +41,10 @@ public class MonitorMojo extends AffectedSpecsMojo {
         super.execute();
         getLog().info("[eMOP] Invoking the Monitor Mojo...");
         long start = System.currentTimeMillis();
+        monitorIncludes = includeLibraries ? new HashSet<>() : retrieveIncludePackages();
+        monitorExcludes = includeNonAffected ? new HashSet<>() : getNonAffected();
         Util.generateNewMonitorFile(getArtifactsDir() + File.separator + monitorFile, affectedSpecs,
-                includeLibraries ? new HashSet<>() : retrieveIncludePackages(),
-                includeNonAffected ? new HashSet<>() : getNonAffected());
+                monitorIncludes, monitorExcludes);
         if (javamopAgent == null) {
             javamopAgent = getLocalRepository().getBasedir() + File.separator + "javamop-agent"
                     + File.separator + "javamop-agent"

--- a/emop-maven-plugin/src/main/java/edu/cornell/RppHandlerMojo.java
+++ b/emop-maven-plugin/src/main/java/edu/cornell/RppHandlerMojo.java
@@ -108,13 +108,9 @@ public class RppHandlerMojo extends MonitorMojo {
                 System.exit(1);
             }
         }
-        getLog().info("BEFORE criticalSpecsSet: " + criticalSpecsSet);
-        getLog().info("BEFORE backgroundSpecsSet: " + backgroundSpecsSet);
         // filtering out specs that are not in the set of all specs
         criticalSpecsSet.retainAll(allSpecs);
         backgroundSpecsSet.retainAll(allSpecs);
-        getLog().info("AFTER criticalSpecsSet: " + criticalSpecsSet);
-        getLog().info("AFTER backgroundSpecsSet: " + backgroundSpecsSet);
         // if there are any specs in the universe that we haven't considered, add them to the critical specs set
         Set<String> remainingSpecs = new HashSet<>(allSpecs);
         remainingSpecs.removeAll(criticalSpecsSet);

--- a/emop-maven-plugin/src/main/java/edu/cornell/RppHandlerMojo.java
+++ b/emop-maven-plugin/src/main/java/edu/cornell/RppHandlerMojo.java
@@ -3,6 +3,7 @@ package edu.cornell;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -26,7 +27,6 @@ public class RppHandlerMojo extends MonitorMojo {
     static SimpleDateFormat timeFormatter = new SimpleDateFormat("yyyy-MM-dd-HH-mm-ss");
 
     File metaInfoDirectory;
-
 
     @Parameter(property = "criticalSpecsFile", defaultValue = "")
     private String criticalSpecsFile;
@@ -80,7 +80,12 @@ public class RppHandlerMojo extends MonitorMojo {
      * Computes the critical specs set and the background specs set.
      */
     private void computeSpecSets() {
-        Set<String> allSpecs = Util.retrieveSpecListFromJar(javamopAgent, getLog());
+        Set<String> allSpecs;
+        if (!Boolean.getBoolean("rpsRpp")) {
+            allSpecs = Util.retrieveSpecListFromJar(javamopAgent, getLog());
+        } else {
+            allSpecs = parseSpecsFile(new File(metaInfoDirectory, "affected-specs.txt").getAbsolutePath());
+        }
         // if we still don't have any spec files, then we'd just need to obtain all specs and run them in critical
         if (criticalSpecsFile == null && backgroundSpecsFile == null) {
             criticalSpecsSet = allSpecs;
@@ -103,6 +108,18 @@ public class RppHandlerMojo extends MonitorMojo {
                 System.exit(1);
             }
         }
+        getLog().info("BEFORE criticalSpecsSet: " + criticalSpecsSet);
+        getLog().info("BEFORE backgroundSpecsSet: " + backgroundSpecsSet);
+        // filtering out specs that are not in the set of all specs
+        criticalSpecsSet.retainAll(allSpecs);
+        backgroundSpecsSet.retainAll(allSpecs);
+        getLog().info("AFTER criticalSpecsSet: " + criticalSpecsSet);
+        getLog().info("AFTER backgroundSpecsSet: " + backgroundSpecsSet);
+        // if there are any specs in the universe that we haven't considered, add them to the critical specs set
+        Set<String> remainingSpecs = new HashSet<>(allSpecs);
+        remainingSpecs.removeAll(criticalSpecsSet);
+        remainingSpecs.removeAll(backgroundSpecsSet);
+        criticalSpecsSet.addAll(remainingSpecs);
     }
 
     /**

--- a/emop-maven-plugin/src/main/java/edu/cornell/RppHandlerMojo.java
+++ b/emop-maven-plugin/src/main/java/edu/cornell/RppHandlerMojo.java
@@ -120,7 +120,7 @@ public class RppHandlerMojo extends MonitorMojo {
             try {
                 Files.copy(javamopAgentFile.toPath(), createdJar.toPath(), StandardCopyOption.REPLACE_EXISTING);
                 Util.generateNewMonitorFile(metaInfoDirectory + File.separator + mode + "-ajc.xml",
-                        specsToMonitor, new HashSet<>(), new HashSet<>());
+                        specsToMonitor, MonitorMojo.monitorIncludes, MonitorMojo.monitorExcludes);
                 Util.replaceFileInJar(createdJar.getAbsolutePath(), "/META-INF/aop-ajc.xml",
                         metaInfoDirectory + File.separator + mode + "-ajc.xml");
             } catch (IOException ex) {

--- a/emop-maven-plugin/src/main/java/edu/cornell/RppMojo.java
+++ b/emop-maven-plugin/src/main/java/edu/cornell/RppMojo.java
@@ -61,14 +61,6 @@ public class RppMojo extends RppHandlerMojo {
         getLog().info("RPP background phase surefire execution end: " + timeFormatter.format(new Date()));
     }
 
-    public static void writeSpecsToFile(Set<String> specs, File file) throws FileNotFoundException {
-        try (PrintWriter writer = new PrintWriter(file)) {
-            for (String spec : specs) {
-                writer.println(spec);
-            }
-        }
-    }
-
     public void updateCriticalAndBackgroundSpecs(String criticalViolationsPath, String bgViolationsPath, String javamopAgent)
             throws MojoExecutionException, FileNotFoundException {
         Set<String> criticalSpecsSet = new HashSet<>();
@@ -90,9 +82,9 @@ public class RppMojo extends RppHandlerMojo {
         File metaCriticalSpecsFile = new File(artifactsDir, "rpp-critical-specs.txt");
         File metaBackgroundSpecsFile = new File(artifactsDir, "rpp-background-specs.txt");
         Set<String> backgroundSpecsSet = new HashSet<>(allSpecs);
-        backgroundSpecsSet.remove(criticalSpecsSet);
-        writeSpecsToFile(criticalSpecsSet, metaCriticalSpecsFile);
-        writeSpecsToFile(backgroundSpecsSet, metaBackgroundSpecsFile);
+        backgroundSpecsSet.removeAll(criticalSpecsSet);
+        Util.writeSpecsToFile(criticalSpecsSet, metaCriticalSpecsFile);
+        Util.writeSpecsToFile(backgroundSpecsSet, metaBackgroundSpecsFile);
     }
 
     /**

--- a/emop-maven-plugin/src/main/java/edu/cornell/RpsRppMojo.java
+++ b/emop-maven-plugin/src/main/java/edu/cornell/RpsRppMojo.java
@@ -8,8 +8,8 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
 
 @Mojo(name = "rps-rpp", requiresDirectInvocation = true, requiresDependencyResolution = ResolutionScope.TEST)
 @Execute(phase = LifecyclePhase.TEST, lifecycle = "rps-rpp")
-public class RpsRppMojo extends MonitorMojo {
+public class RpsRppMojo extends RppMojo {
     public void execute() throws MojoExecutionException {
-        getLog().info("[eMOP] Invoking the RPS-RPP Mojo...");
+        super.execute();
     }
 }

--- a/emop-maven-plugin/src/main/java/edu/cornell/RpsRppMojo.java
+++ b/emop-maven-plugin/src/main/java/edu/cornell/RpsRppMojo.java
@@ -1,0 +1,15 @@
+package edu.cornell;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Execute;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+
+@Mojo(name = "rps-rpp", requiresDirectInvocation = true, requiresDependencyResolution = ResolutionScope.TEST)
+@Execute(phase = LifecyclePhase.TEST, lifecycle = "rps-rpp")
+public class RpsRppMojo extends MonitorMojo {
+    public void execute() throws MojoExecutionException {
+        getLog().info("[eMOP] Invoking the RPS-RPP Mojo...");
+    }
+}

--- a/emop-maven-plugin/src/main/resources/META-INF/maven/lifecycle.xml
+++ b/emop-maven-plugin/src/main/resources/META-INF/maven/lifecycle.xml
@@ -72,6 +72,9 @@
               <goal>monitor</goal>
               <goal>rpp-handler</goal>
             </goals>
+            <configuration>
+              <rpsRpp>true</rpsRpp>
+            </configuration>
           </execution>
         </executions>
       </phase>

--- a/emop-maven-plugin/src/main/resources/META-INF/maven/lifecycle.xml
+++ b/emop-maven-plugin/src/main/resources/META-INF/maven/lifecycle.xml
@@ -61,4 +61,23 @@
       </phase>
     </phases>
   </lifecycle>
+  <lifecycle>
+    <id>rps-rpp</id>
+    <phases>
+      <phase>
+        <id>process-test-classes</id>
+        <executions>
+          <execution>
+            <goals>
+              <goal>monitor</goal>
+              <goal>rpp-handler</goal>
+            </goals>
+          </execution>
+        </executions>
+      </phase>
+      <phase>
+        <id>test</id>
+      </phase>
+    </phases>
+  </lifecycle>
 </lifecycles>


### PR DESCRIPTION
An integrated version of RPS and RPP. 

To run RPS + RPP:
```
mvn emop:rps-rpp
```

Currently, the following design decisions are made:

- Any specs previously stored in the meta-files for RPP's critical and background specs that are not affected (as computed by RPS) will not be monitored in either the critical or background runs.
- Any newly-found affected specs that were not in the meta-files for RPP's critical and background specs will be added to the *critical* phase. 