### PR TITLE
No impacted classes fix

### DIFF
--- a/emop-core/src/main/java/edu/cornell/emop/maven/SurefireMojoInterceptor.java
+++ b/emop-core/src/main/java/edu/cornell/emop/maven/SurefireMojoInterceptor.java
@@ -5,8 +5,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import static edu.illinois.starts.constants.StartsConstants.STARTS_EXCLUDE_PROPERTY;
-
 /**
  * This class is adapted from STARTS's SurefireMojoInterceptor
  * (https://github.com/TestingResearchIllinois/starts/blob/master/...

--- a/emop-maven-plugin/src/main/java/edu/cornell/AffectedSpecsMojo.java
+++ b/emop-maven-plugin/src/main/java/edu/cornell/AffectedSpecsMojo.java
@@ -72,6 +72,9 @@ public class AffectedSpecsMojo extends ImpactedClassMojo {
 
     public void execute() throws MojoExecutionException {
         super.execute();
+        if (getImpacted().isEmpty()) {
+            return;
+        }
         getLog().info("[eMOP] Invoking the AffectedSpecs Mojo...");
         long start = System.currentTimeMillis();
         // If only computing changed classes, then these lines can stay the same

--- a/emop-maven-plugin/src/main/java/edu/cornell/ImpactedClassMojo.java
+++ b/emop-maven-plugin/src/main/java/edu/cornell/ImpactedClassMojo.java
@@ -39,8 +39,8 @@ public class ImpactedClassMojo extends ImpactedMojo {
         getLog().info("[eMOP Timer] Execute ImpactedClasses Mojo takes " + (end - start) + " ms");
         getLog().info("[eMOP] Total number of classes: " + (getOldClasses().size() + getNewClasses().size()));
         if (getImpacted().isEmpty()) {
-            getLog().info("[eMOP] No impacted classes, terminating...");
-            System.exit(0);
+            getLog().info("[eMOP] No impacted classes, returning...");
+//            System.exit(0);
         }
     }
 }

--- a/emop-maven-plugin/src/main/java/edu/cornell/MonitorMojo.java
+++ b/emop-maven-plugin/src/main/java/edu/cornell/MonitorMojo.java
@@ -52,6 +52,7 @@ public class MonitorMojo extends AffectedSpecsMojo {
             if (!AgentLoader.loadDynamicAgent("JavaAgent.class")) {
                 throw new MojoExecutionException("Could not attach agent");
             }
+            getLog().info("No impacted classes");
 //            throw new MojoExecutionException("no impacted classes");
 //            setIncludes(new ArrayList<>());
 //            List<String> lst = new ArrayList<>();

--- a/emop-maven-plugin/src/main/java/edu/cornell/MonitorMojo.java
+++ b/emop-maven-plugin/src/main/java/edu/cornell/MonitorMojo.java
@@ -2,9 +2,12 @@ package edu.cornell;
 
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
+import edu.cornell.emop.maven.AgentLoader;
 import edu.cornell.emop.util.Util;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Mojo;
@@ -43,6 +46,20 @@ public class MonitorMojo extends AffectedSpecsMojo {
 
     public void execute() throws MojoExecutionException {
         super.execute();
+        if (getImpacted().isEmpty()) {
+            System.setProperty("exiting-rps", "true");
+            System.setProperty("rps-test-excludes", "**/Test*,**/*Test,**/*Tests,**/*TestCase");
+            if (!AgentLoader.loadDynamicAgent("JavaAgent.class")) {
+                throw new MojoExecutionException("Could not attach agent");
+            }
+//            throw new MojoExecutionException("no impacted classes");
+//            setIncludes(new ArrayList<>());
+//            List<String> lst = new ArrayList<>();
+//            lst.add("**/*Test");
+//            // getTestClasses("MonitorMojo.execute")
+//            setExcludes(lst);
+            return;
+        }
         getLog().info("[eMOP] Invoking the Monitor Mojo...");
         long start = System.currentTimeMillis();
         monitorIncludes = includeLibraries ? new HashSet<>() : retrieveIncludePackages();

--- a/emop-maven-plugin/src/main/java/edu/cornell/MonitorMojo.java
+++ b/emop-maven-plugin/src/main/java/edu/cornell/MonitorMojo.java
@@ -52,13 +52,7 @@ public class MonitorMojo extends AffectedSpecsMojo {
             if (!AgentLoader.loadDynamicAgent("JavaAgent.class")) {
                 throw new MojoExecutionException("Could not attach agent");
             }
-            getLog().info("No impacted classes");
-//            throw new MojoExecutionException("no impacted classes");
-//            setIncludes(new ArrayList<>());
-//            List<String> lst = new ArrayList<>();
-//            lst.add("**/*Test");
-//            // getTestClasses("MonitorMojo.execute")
-//            setExcludes(lst);
+            getLog().info("No impacted classes mode detected MonitorMojo");
             return;
         }
         getLog().info("[eMOP] Invoking the Monitor Mojo...");
@@ -67,7 +61,6 @@ public class MonitorMojo extends AffectedSpecsMojo {
         monitorExcludes = includeNonAffected ? new HashSet<>() : getNonAffected();
         Util.generateNewMonitorFile(getArtifactsDir() + File.separator + monitorFile, affectedSpecs,
                 monitorIncludes, monitorExcludes);
-        getLog().info("rps-rpp: " + rpsRpp);
         if (rpsRpp) {
             getLog().info("In mode RPS-RPP, writing the list of affected specs to affected-specs.txt...");
             try {

--- a/emop-maven-plugin/src/main/java/edu/cornell/RppHandlerMojo.java
+++ b/emop-maven-plugin/src/main/java/edu/cornell/RppHandlerMojo.java
@@ -178,6 +178,7 @@ public class RppHandlerMojo extends MonitorMojo {
         metaInfoDirectory = new File(getArtifactsDir());
         // prepare the two jars
         setupJars();
+        System.setProperty("running-rpp", "true");
         // load agent that will harness surefire and manipulate arguments to surefire before test execution
         if (!AgentLoader.loadDynamicAgent("JavaAgent.class")) {
             throw new MojoExecutionException("Could not attach agent");

--- a/emop-maven-plugin/src/main/java/edu/cornell/RpsMojo.java
+++ b/emop-maven-plugin/src/main/java/edu/cornell/RpsMojo.java
@@ -11,5 +11,6 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
 public class RpsMojo extends MonitorMojo {
     public void execute() throws MojoExecutionException {
         getLog().info("[eMOP] Invoking the RPS Mojo...");
+        System.setProperty("exiting-rps", "false");
     }
 }


### PR DESCRIPTION
Previously, we exited the entire process if the module/project had no .class files. This caused a problem for multimodule projects, because a single module with no .class files would stop test execution for all subsequent modules. As a fix, we skip tests if there are no .class files.