### PR TITLE
Search for source files in additional standard directories

### DIFF
--- a/emop-maven-plugin/pom.xml
+++ b/emop-maven-plugin/pom.xml
@@ -19,6 +19,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-project</artifactId>
+      <version>2.2.1</version>
+    </dependency>
+    <dependency>
       <groupId>edu.cornell</groupId>
       <artifactId>emop-core</artifactId>
       <version>1.0-SNAPSHOT</version>

--- a/emop-maven-plugin/src/main/java/edu/cornell/AffectedSpecsMojo.java
+++ b/emop-maven-plugin/src/main/java/edu/cornell/AffectedSpecsMojo.java
@@ -287,6 +287,11 @@ public class AffectedSpecsMojo extends ImpactedClassMojo {
                 Path classFile = Paths.get(new URI(changedClass)).toAbsolutePath();
                 Path classesDir = null;
 
+                if (!classFile.toFile().exists()) {
+                    getLog().debug("Class file does not exist: " + classFile.toString());
+                    continue;
+                }
+
                 if (classFile.startsWith(mainClassesDir)) {
                     classesDir = mainClassesDir;
                 } else if (classFile.startsWith(testClassesDir)) {

--- a/emop-maven-plugin/src/main/java/edu/cornell/AffectedSpecsMojo.java
+++ b/emop-maven-plugin/src/main/java/edu/cornell/AffectedSpecsMojo.java
@@ -291,7 +291,7 @@ public class AffectedSpecsMojo extends ImpactedClassMojo {
                 Path classesDir = null;
 
                 if (!classFile.toFile().exists()) {
-                    getLog().debug("Class file does not exist: " + classFile.toString());
+                    getLog().warn("Class file does not exist: " + classFile.toString());
                     continue;
                 }
 


### PR DESCRIPTION
Previously, source files wouldn't be found if they were located in `target/generated-sources` or `target/generated-test-sources`. This change searches all source directories known to Maven.