### PR TITLE
Fix VMS regression

### DIFF
--- a/emop-maven-plugin/src/main/java/edu/cornell/VmsMojo.java
+++ b/emop-maven-plugin/src/main/java/edu/cornell/VmsMojo.java
@@ -402,14 +402,12 @@ public class VmsMojo extends DiffMojo {
                                               Map<String, Map<Integer, Integer>> offsets,
                                               Map<String, Set<Integer>> modifiedLines) {
         Set<Violation> violationsToRemove = new HashSet<>();
-
-        Set<Violation> likelyNewViolations = new HashSet<>();
-        likelyNewViolations.addAll(newViolations);
-        likelyNewViolations.removeAll(oldViolations);
-        for (Violation likelyNewViolation : likelyNewViolations) {
+        for (Violation newViolation : newViolations) {
             for (Violation oldViolation : oldViolations) {
-                if (isSameViolationAfterDifferences(oldViolation, likelyNewViolation, renames, offsets, modifiedLines)) {
-                    violationsToRemove.add(likelyNewViolation);
+                if (oldViolation.equals(newViolation)
+                        || isSameViolationAfterDifferences(oldViolation, newViolation, renames, offsets, modifiedLines)
+                ) {
+                    violationsToRemove.add(newViolation);
                     break;
                 }
             }


### PR DESCRIPTION
Fix the VMS regression that is introduced at https://github.com/SoftEngResearch/emop/commit/fc6da1b2e85bac4ee4d8d7d5aae4f3e748d3f63c, which will cause VMS to output the wrong set of new violations.