### PR TITLE
Resolve unsafeness w.r.t. 3rd party libraries

### DIFF
--- a/emop-core/src/main/java/edu/cornell/emop/util/Util.java
+++ b/emop-core/src/main/java/edu/cornell/emop/util/Util.java
@@ -105,7 +105,7 @@ public class Util {
         } catch (IOException ex) {
             ex.printStackTrace();
         }
-        return null;
+        return new HashSet<>();
     }
 
     public static Set<String> retrieveSpecListFromJar(String jarPath, Log log) {

--- a/emop-core/src/main/java/edu/cornell/emop/util/Util.java
+++ b/emop-core/src/main/java/edu/cornell/emop/util/Util.java
@@ -23,6 +23,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.maven.plugin.logging.Log;
 
@@ -75,6 +77,35 @@ public class Util {
         } catch (IOException ex) {
             ex.printStackTrace();
         }
+    }
+
+    /**
+     * Obtains a set of all the specifications in a JavaMOP agent jar.
+     *
+     * @param jarPath Path to the .jar file
+     * @param pathInJar Path in the .jar file that contains all the specifications
+     * @return A set that contains all specs used in the JavaMOP agent.
+     */
+    public static Set<String> getFullSpecSet(String jarPath, String pathInJar) {
+        URI jarFile = URI.create("jar:file:" + jarPath);
+        try (FileSystem jarfs = FileSystems.newFileSystem(jarFile, new HashMap<String, String>())) {
+            Path pathInJarFile = jarfs.getPath(pathInJar);
+            try (Stream<Path> stream = Files.list(pathInJarFile)) {
+                Set<String> specs = stream
+                        .filter(file -> !Files.isDirectory(file))
+                        .map(Path::getFileName)
+                        .map(Path::toString)
+                        .map(spec -> spec.split("[.]")[0])
+                        .filter(spec -> !spec.contains("$"))
+                        .filter(spec -> spec.contains("Aspect"))
+                        .collect(Collectors.toSet());
+                specs.remove("BaseAspect");
+                return specs;
+            }
+        } catch (IOException ex) {
+            ex.printStackTrace();
+        }
+        return null;
     }
 
     public static Set<String> retrieveSpecListFromJar(String jarPath, Log log) {

--- a/emop-maven-plugin/src/main/java/edu/cornell/AffectedSpecsMojo.java
+++ b/emop-maven-plugin/src/main/java/edu/cornell/AffectedSpecsMojo.java
@@ -47,7 +47,7 @@ public class AffectedSpecsMojo extends ImpactedClassMojo {
     private static final int SPEC_INDEX_IN_MSG = 5;
 
     /**
-     * The path that specify the Javamop Agent JAR file.
+     * The path to the Javamop Agent JAR file.
      */
     @Parameter(property = "javamopAgent")
     protected String javamopAgent;

--- a/emop-maven-plugin/src/main/java/edu/cornell/MonitorMojo.java
+++ b/emop-maven-plugin/src/main/java/edu/cornell/MonitorMojo.java
@@ -15,29 +15,9 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
 @Mojo(name = "monitor", requiresDirectInvocation = true, requiresDependencyResolution = ResolutionScope.TEST)
 public class MonitorMojo extends AffectedSpecsMojo {
 
-
     public static final String AGENT_CONFIGURATION_FILE = "new-aop-ajc.xml";
     protected static Set<String> monitorIncludes;
     protected static Set<String> monitorExcludes;
-
-    /**
-     * The path that specify the Javamop Agent JAR file.
-     */
-    @Parameter(property = "javamopAgent")
-    private String javamopAgent;
-
-    /**
-     * The path that specify the Javamop Agent JAR file.
-     */
-    @Parameter(property = "includeNonAffected", required = false, defaultValue = "true")
-    private boolean includeNonAffected;
-
-    /**
-     * Whether to instrument third-party libraries.
-     * Setting this option to false triggers the ^l weak RPS variants.
-     */
-    @Parameter(property = "includeLibraries", required = false, defaultValue = "true")
-    private boolean includeLibraries;
 
     @Parameter(property = "rpsRpp", defaultValue = "false")
     private boolean rpsRpp;
@@ -67,12 +47,6 @@ public class MonitorMojo extends AffectedSpecsMojo {
                 throw new RuntimeException(ex);
             }
             System.setProperty("rpsRpp", "true");
-        }
-        if (javamopAgent == null) {
-            javamopAgent = getLocalRepository().getBasedir() + File.separator + "javamop-agent"
-                    + File.separator + "javamop-agent"
-                    + File.separator + "1.0"
-                    + File.separator + "javamop-agent-1.0.jar";
         }
         Util.replaceFileInJar(javamopAgent, "/META-INF/aop-ajc.xml",
                 getArtifactsDir() + File.separator + AGENT_CONFIGURATION_FILE);


### PR DESCRIPTION
Resolve unsafeness w.r.t. 3rd party libraries, by moving some flags to a previous Mojo, and revert to base RV if dependency changes. Reverting to base RV requires the following:
1. Use the full specification list
2. Instrument in libraries
3. Instrument in non-affected classes