### PR TITLE
Add affected test computation parameters for emop

### DIFF
--- a/emop-maven-plugin/src/main/java/edu/cornell/ImpactedHybridMojo.java
+++ b/emop-maven-plugin/src/main/java/edu/cornell/ImpactedHybridMojo.java
@@ -30,9 +30,12 @@ public class ImpactedHybridMojo extends HybridMojo {
      */
     protected boolean debug;
 
+    protected boolean computeAffectedTests;
+
     public void execute() throws MojoExecutionException {
         setUpdateMethodsChecksums(true);
         setComputeImpactedMethods(true);
+        setComputeAffectedTests(computeAffectedTests);
         long start = System.currentTimeMillis();
         getLog().info("[eMOP] Invoking the ImpactedMethods Mojo...");
         super.execute();

--- a/emop-maven-plugin/src/main/java/edu/cornell/ImpactedMethodsMojo.java
+++ b/emop-maven-plugin/src/main/java/edu/cornell/ImpactedMethodsMojo.java
@@ -30,11 +30,17 @@ public class ImpactedMethodsMojo extends MethodsMojo {
      */
     protected boolean debug;
 
+    /**
+     * Set this to "true" to compute affected test classes as well.
+     */
+    protected boolean computeAffectedTests;
+
     public void execute() throws MojoExecutionException {
         setUpdateMethodsChecksums(updateChecksums);
         setComputeImpactedMethods(computeImpactedMethods);
         setIncludeVariables(includeVariables);
         setDebug(debug);
+        setComputeAffectedTests(computeAffectedTests);
         long start = System.currentTimeMillis();
         getLog().info("[eMOP] Invoking the ImpactedMethods Mojo...");
         super.execute();

--- a/emop-maven-plugin/src/main/java/edu/cornell/MonitorHybridMojo.java
+++ b/emop-maven-plugin/src/main/java/edu/cornell/MonitorHybridMojo.java
@@ -59,11 +59,18 @@ public class MonitorHybridMojo extends AffectedSpecsHybridMojo {
     @Parameter(property = "debug", defaultValue = "flase")
     private boolean debugTemp;
 
+    /**
+     * Set this to "true" to compute affected test classes as well.
+     */
+    @Parameter(property = "computeAffectedTests", defaultValue = FALSE)
+    private boolean computeAffectedTestsTemp;
+
     public void execute() throws MojoExecutionException {
         includeVariables = includeVariablesTemp;
         updateChecksums = updateChecksumsTemp;
         computeImpactedMethods = computeImpactedMethodsTemp;
         debug = debugTemp;
+        computeAffectedTests = computeAffectedTestsTemp;
         super.execute();
 
         if (getAffectedMethods().isEmpty() && getAffectedClasses().isEmpty()) {
@@ -84,7 +91,8 @@ public class MonitorHybridMojo extends AffectedSpecsHybridMojo {
         if (debug) {
             getLog().info("AffectedSpecs: " + affectedSpecs);
         }
-        Util.generateNewAgentConfigurationFile(getArtifactsDir() + File.separator + AGENT_CONFIGURATION_FILE, affectedSpecs,
+        Util.generateNewAgentConfigurationFile(getArtifactsDir() + File.separator + AGENT_CONFIGURATION_FILE,
+                affectedSpecs,
                 monitorIncludes, monitorExcludes);
         if (javamopAgent == null) {
             javamopAgent = getLocalRepository().getBasedir() + File.separator + "javamop-agent"

--- a/emop-maven-plugin/src/main/java/edu/cornell/MonitorMethodsMojo.java
+++ b/emop-maven-plugin/src/main/java/edu/cornell/MonitorMethodsMojo.java
@@ -58,11 +58,18 @@ public class MonitorMethodsMojo extends AffectedSpecsMethodsMojo {
     @Parameter(property = "debug", defaultValue = "flase")
     private boolean debugTemp;
 
+    /**
+     * Set this to "true" to compute affected test classes as well.
+     */
+    @Parameter(property = "computeAffectedTests", defaultValue = FALSE)
+    private boolean computeAffectedTestsTemp;
+
     public void execute() throws MojoExecutionException {
         includeVariables = includeVariablesTemp;
         updateChecksums = updateChecksumsTemp;
         computeImpactedMethods = computeImpactedMethodsTemp;
         debug = debugTemp;
+        computeAffectedTests = computeAffectedTestsTemp;
         super.execute();
 
         // If there is no affected methods, then we should not instrument anything.
@@ -85,7 +92,8 @@ public class MonitorMethodsMojo extends AffectedSpecsMethodsMojo {
         if (debug) {
             getLog().info("AffectedSpecs: " + affectedSpecs);
         }
-        Util.generateNewAgentConfigurationFile(getArtifactsDir() + File.separator + AGENT_CONFIGURATION_FILE, affectedSpecs,
+        Util.generateNewAgentConfigurationFile(getArtifactsDir() + File.separator + AGENT_CONFIGURATION_FILE,
+                affectedSpecs,
                 monitorIncludes, monitorExcludes);
         if (javamopAgent == null) {
             javamopAgent = getLocalRepository().getBasedir() + File.separator + "javamop-agent"


### PR DESCRIPTION
This PR adds a small change to be able to control whether we want to compute affected test classes or not from emop since the computation happens in STARTS actually.