### PR TITLE
Add Non affected classes computation flag to emop

### DIFF
--- a/emop-maven-plugin/src/main/java/edu/cornell/ImpactedHybridMojo.java
+++ b/emop-maven-plugin/src/main/java/edu/cornell/ImpactedHybridMojo.java
@@ -35,14 +35,10 @@ public class ImpactedHybridMojo extends HybridMojo {
      */
     protected boolean includeNonAffectedClasses;
 
-    public void setIncludeNonAffected(boolean includeNonAffected) {
-        this.includeNonAffectedClasses = includeNonAffected;
-    }
-
     public void execute() throws MojoExecutionException {
         setUpdateMethodsChecksums(true);
         setComputeImpactedMethods(true);
-        super.setIncludeNonAffectedClasses(includeNonAffectedClasses);
+        setIncludeNonAffectedClasses(includeNonAffectedClasses);
         long start = System.currentTimeMillis();
         getLog().info("[eMOP] Invoking the ImpactedMethods Mojo...");
         super.execute();

--- a/emop-maven-plugin/src/main/java/edu/cornell/ImpactedHybridMojo.java
+++ b/emop-maven-plugin/src/main/java/edu/cornell/ImpactedHybridMojo.java
@@ -30,9 +30,19 @@ public class ImpactedHybridMojo extends HybridMojo {
      */
     protected boolean debug;
 
+    /**
+     * Parameter to determine whether to include non affectedClasses.
+     */
+    protected boolean includeNonAffectedClasses;
+
+    public void setIncludeNonAffected(boolean includeNonAffected) {
+        this.includeNonAffectedClasses = includeNonAffected;
+    }
+
     public void execute() throws MojoExecutionException {
         setUpdateMethodsChecksums(true);
         setComputeImpactedMethods(true);
+        super.setIncludeNonAffectedClasses(includeNonAffectedClasses);
         long start = System.currentTimeMillis();
         getLog().info("[eMOP] Invoking the ImpactedMethods Mojo...");
         super.execute();

--- a/emop-maven-plugin/src/main/java/edu/cornell/ImpactedMethodsMojo.java
+++ b/emop-maven-plugin/src/main/java/edu/cornell/ImpactedMethodsMojo.java
@@ -30,11 +30,21 @@ public class ImpactedMethodsMojo extends MethodsMojo {
      */
     protected boolean debug;
 
+    /**
+     * Parameter to determine whether to include non affectedClasses.
+     */
+    protected boolean includeNonAffectedClasses;
+
+    public void setIncludeNonAffected(boolean includeNonAffected) {
+        this.includeNonAffectedClasses = includeNonAffected;
+    }
+
     public void execute() throws MojoExecutionException {
         setUpdateMethodsChecksums(updateChecksums);
         setComputeImpactedMethods(computeImpactedMethods);
         setIncludeVariables(includeVariables);
         setDebug(debug);
+        super.setIncludeNonAffectedClasses(includeNonAffectedClasses);
         long start = System.currentTimeMillis();
         getLog().info("[eMOP] Invoking the ImpactedMethods Mojo...");
         super.execute();

--- a/emop-maven-plugin/src/main/java/edu/cornell/ImpactedMethodsMojo.java
+++ b/emop-maven-plugin/src/main/java/edu/cornell/ImpactedMethodsMojo.java
@@ -35,16 +35,12 @@ public class ImpactedMethodsMojo extends MethodsMojo {
      */
     protected boolean includeNonAffectedClasses;
 
-    public void setIncludeNonAffected(boolean includeNonAffected) {
-        this.includeNonAffectedClasses = includeNonAffected;
-    }
-
     public void execute() throws MojoExecutionException {
         setUpdateMethodsChecksums(updateChecksums);
         setComputeImpactedMethods(computeImpactedMethods);
         setIncludeVariables(includeVariables);
         setDebug(debug);
-        super.setIncludeNonAffectedClasses(includeNonAffectedClasses);
+        setIncludeNonAffectedClasses(includeNonAffectedClasses);
         long start = System.currentTimeMillis();
         getLog().info("[eMOP] Invoking the ImpactedMethods Mojo...");
         super.execute();

--- a/emop-maven-plugin/src/main/java/edu/cornell/MonitorHybridMojo.java
+++ b/emop-maven-plugin/src/main/java/edu/cornell/MonitorHybridMojo.java
@@ -26,7 +26,7 @@ public class MonitorHybridMojo extends AffectedSpecsHybridMojo {
     private String javamopAgent;
 
     /**
-     * The path that specify the Javamop Agent JAR file.
+     * The path that specify whether to include non affected classes.
      */
     @Parameter(property = "includeNonAffected", required = false, defaultValue = "true")
     private boolean includeNonAffected;
@@ -79,13 +79,13 @@ public class MonitorHybridMojo extends AffectedSpecsHybridMojo {
         getLog().info("[eMOP] Invoking the Hybrid Monitor Mojo...");
         long start = System.currentTimeMillis();
         monitorIncludes = includeLibraries ? new HashSet<>() : retrieveIncludePackages();
-        monitorExcludes = new HashSet<>();
+        monitorExcludes = includeNonAffected ? new HashSet<>() : getNonAffectedClasses();
         getLog().info("AffectedSpecs: " + affectedSpecs.size());
         if (debug) {
             getLog().info("AffectedSpecs: " + affectedSpecs);
         }
-        Util.generateNewAgentConfigurationFile(getArtifactsDir() + File.separator + AGENT_CONFIGURATION_FILE, affectedSpecs,
-                monitorIncludes, monitorExcludes);
+        Util.generateNewAgentConfigurationFile(getArtifactsDir() + File.separator + AGENT_CONFIGURATION_FILE,
+                affectedSpecs, monitorIncludes, monitorExcludes);
         if (javamopAgent == null) {
             javamopAgent = getLocalRepository().getBasedir() + File.separator + "javamop-agent"
                     + File.separator + "javamop-agent"

--- a/emop-maven-plugin/src/main/java/edu/cornell/MonitorHybridMojo.java
+++ b/emop-maven-plugin/src/main/java/edu/cornell/MonitorHybridMojo.java
@@ -29,7 +29,7 @@ public class MonitorHybridMojo extends AffectedSpecsHybridMojo {
      * The path that specify whether to include non affected classes.
      */
     @Parameter(property = "includeNonAffected", required = false, defaultValue = "true")
-    private boolean includeNonAffected;
+    private boolean includeNonAffectedTemp;
 
     /**
      * Whether to instrument third-party libraries.
@@ -64,6 +64,7 @@ public class MonitorHybridMojo extends AffectedSpecsHybridMojo {
         updateChecksums = updateChecksumsTemp;
         computeImpactedMethods = computeImpactedMethodsTemp;
         debug = debugTemp;
+        includeNonAffectedClasses = includeNonAffectedTemp;
         super.execute();
 
         if (getAffectedMethods().isEmpty() && getAffectedClasses().isEmpty()) {
@@ -79,7 +80,7 @@ public class MonitorHybridMojo extends AffectedSpecsHybridMojo {
         getLog().info("[eMOP] Invoking the Hybrid Monitor Mojo...");
         long start = System.currentTimeMillis();
         monitorIncludes = includeLibraries ? new HashSet<>() : retrieveIncludePackages();
-        monitorExcludes = includeNonAffected ? new HashSet<>() : getNonAffectedClasses();
+        monitorExcludes = includeNonAffectedTemp ? new HashSet<>() : getNonAffectedClasses();
         getLog().info("AffectedSpecs: " + affectedSpecs.size());
         if (debug) {
             getLog().info("AffectedSpecs: " + affectedSpecs);

--- a/emop-maven-plugin/src/main/java/edu/cornell/MonitorMethodsMojo.java
+++ b/emop-maven-plugin/src/main/java/edu/cornell/MonitorMethodsMojo.java
@@ -25,7 +25,7 @@ public class MonitorMethodsMojo extends AffectedSpecsMethodsMojo {
     private String javamopAgent;
 
     /**
-     * The path that specify the Javamop Agent JAR file.
+     * The path that specify whether to include non affected classes.
      */
     @Parameter(property = "includeNonAffected", required = false, defaultValue = "true")
     private boolean includeNonAffected;
@@ -63,6 +63,7 @@ public class MonitorMethodsMojo extends AffectedSpecsMethodsMojo {
         updateChecksums = updateChecksumsTemp;
         computeImpactedMethods = computeImpactedMethodsTemp;
         debug = debugTemp;
+        setIncludeNonAffected(includeNonAffected);
         super.execute();
 
         // If there is no affected methods, then we should not instrument anything.
@@ -80,13 +81,13 @@ public class MonitorMethodsMojo extends AffectedSpecsMethodsMojo {
         long start = System.currentTimeMillis();
 
         monitorIncludes = includeLibraries ? new HashSet<>() : retrieveIncludePackages();
-        monitorExcludes = new HashSet<>();
+        monitorExcludes = includeNonAffected ? new HashSet<>() : getNonAffectedClasses();
         getLog().info("AffectedSpecs: " + affectedSpecs.size());
         if (debug) {
             getLog().info("AffectedSpecs: " + affectedSpecs);
         }
-        Util.generateNewAgentConfigurationFile(getArtifactsDir() + File.separator + AGENT_CONFIGURATION_FILE, affectedSpecs,
-                monitorIncludes, monitorExcludes);
+        Util.generateNewAgentConfigurationFile(getArtifactsDir() + File.separator + AGENT_CONFIGURATION_FILE,
+                affectedSpecs, monitorIncludes, monitorExcludes);
         if (javamopAgent == null) {
             javamopAgent = getLocalRepository().getBasedir() + File.separator + "javamop-agent"
                     + File.separator + "javamop-agent"

--- a/emop-maven-plugin/src/main/java/edu/cornell/MonitorMethodsMojo.java
+++ b/emop-maven-plugin/src/main/java/edu/cornell/MonitorMethodsMojo.java
@@ -28,7 +28,7 @@ public class MonitorMethodsMojo extends AffectedSpecsMethodsMojo {
      * The path that specify whether to include non affected classes.
      */
     @Parameter(property = "includeNonAffected", required = false, defaultValue = "true")
-    private boolean includeNonAffected;
+    private boolean includeNonAffectedTemp;
 
     /**
      * Whether to instrument third-party libraries.
@@ -63,7 +63,7 @@ public class MonitorMethodsMojo extends AffectedSpecsMethodsMojo {
         updateChecksums = updateChecksumsTemp;
         computeImpactedMethods = computeImpactedMethodsTemp;
         debug = debugTemp;
-        setIncludeNonAffected(includeNonAffected);
+        includeNonAffectedClasses = includeNonAffectedTemp;
         super.execute();
 
         // If there is no affected methods, then we should not instrument anything.
@@ -81,7 +81,7 @@ public class MonitorMethodsMojo extends AffectedSpecsMethodsMojo {
         long start = System.currentTimeMillis();
 
         monitorIncludes = includeLibraries ? new HashSet<>() : retrieveIncludePackages();
-        monitorExcludes = includeNonAffected ? new HashSet<>() : getNonAffectedClasses();
+        monitorExcludes = includeNonAffectedTemp ? new HashSet<>() : getNonAffectedClasses();
         getLog().info("AffectedSpecs: " + affectedSpecs.size());
         if (debug) {
             getLog().info("AffectedSpecs: " + affectedSpecs);


### PR DESCRIPTION
This PR adds parameters so that we can control whether we want `nonAffectedClass` computations.