### PR TITLE
Add code for Method RPS that enables tracking 3rd party dependency change

### DIFF
--- a/emop-maven-plugin/src/main/java/edu/cornell/ImpactedMethodsMojo.java
+++ b/emop-maven-plugin/src/main/java/edu/cornell/ImpactedMethodsMojo.java
@@ -57,6 +57,16 @@ public class ImpactedMethodsMojo extends MethodsMojo {
         super.execute();
         long end = System.currentTimeMillis();
         getLog().info("[eMOP Timer] Execute ImpactedMethods Mojo takes " + (end - start) + " ms");
+
+        String cpString = Writer.pathToString(getSureFireClassPath().getClassPath());
+        // TODO: Change STARTS so that it exposes the three methods needed here
+        List<String> sfPathElements = getCleanClassPath(cpString);
+        if (!isSameClassPath(sfPathElements) || !hasSameJarChecksum(sfPathElements)) {
+            Writer.writeClassPath(cpString, artifactsDir);
+            Writer.writeJarChecksums(sfPathElements, artifactsDir, jarCheckSums);
+            dependencyChangeDetected = true;
+            getLog().info("Dependencies changed! Reverting to Base RV.");
+        }
     }
 
     // Copied from STARTS


### PR DESCRIPTION
After investigating the problem to figure what is causing the lack of 3rd party library monitoring, I figured that it was in `ImpactedMethodsMojo.java` that lacked the added code segment to store 3rd party jar-to-checksum mapping and identifying the changes in dependencies.
Hybrid level RPS already was working with this so it didn't need any change.
I have tested this in a sample project which utilizes a 3rd party library, but it needs to be tested on a large project especially the one we inspected in our previous meeting with Pengyue and Mustafa.
